### PR TITLE
feat(layout): per-repo layout overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-06-24
+
+### Added
+
+- Per-repo layout overrides at `<project>/.sessionizer/config.toml`
+- `resolveLayoutConfig()` — repo-local layout on new workspace bootstrap, global fallback
+- Clear errors when a repo-local config file exists but is invalid
+
+### Changed
+
+- README documents per-repo override lookup, examples, and behavior table
+
+## [0.1.0] - 2026-06-23
+
+### Added
+
+- Project sessionizer — `fzf` picker, focus existing workspaces, layout bootstrap for new ones
+- Worktree picker — create or reopen Git worktree workspaces, with duplicate-branch recovery
+- Config-driven tab/pane layout via global `config.toml`
+- `fzf` previews — optional `bat` for README previews in the picker
+- macOS platform declaration in plugin manifest
+- Prerequisites: Herdr >= 0.7.0, Bun, `fzf`

--- a/README.md
+++ b/README.md
@@ -260,6 +260,8 @@ description = "create worktree workspace"
 
 ## Development
 
+See [CHANGELOG.md](CHANGELOG.md) for release history.
+
 ```sh
 bun run typecheck
 bun run test

--- a/README.md
+++ b/README.md
@@ -226,5 +226,9 @@ See [CHANGELOG.md](CHANGELOG.md) for release history.
 ```sh
 bun run typecheck
 bun run test
+bun run release -- 0.2.1 --dry-run
+bun run release:tag -- 0.2.1 --dry-run
 bun run sessionizer
 ```
+
+Use `bun run release -- <version>` on the release-prep branch to update version files, then run `bun run release:tag -- <version>` from merged `main` to create and push the annotated release tag.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ First tab shape:
 - `[[tabs.<name>.panes]]` — panes inside the tab; `from` + `split` (`right` or `down`) define the split tree
 - `command` — exact command a pane runs (`nvim`, `pi`, `claude`, `opencode`, etc.)
 
+If you launch a worktree with `--command`, exactly one pane in that layout must opt in with `accept_command_override = true`. The generated default config leaves this off until you choose which pane should receive the raw command.
+
 ### Per-repo layout overrides
 
 A repository can declare its own layout for **new** workspace bootstrap. Put a layout-only config at:
@@ -231,4 +233,4 @@ bun run release:tag -- 0.2.1 --dry-run
 bun run sessionizer
 ```
 
-Use `bun run release -- <version>` on the release-prep branch to update version files, then run `bun run release:tag -- <version>` from merged `main` to create and push the annotated release tag.
+Use `bun run release -- <version>` on the release-prep branch to update version files, then run `bun run release:tag -- <version>` from merged `main` to create and push the annotated `v<version>` release tag.

--- a/README.md
+++ b/README.md
@@ -168,20 +168,12 @@ Invalid repo-local config fails with an error that names the file path. Reopenin
 | Worktree creates a new workspace            | Repo override at checkout `cwd`, else global default |
 | Focus or reopen an existing workspace       | No relayout                                          |
 
-#### Example: three layouts side by side
+#### Example repo override
 
-With a global default like the [example layout](#example-layout) above, two repos can override it independently:
-
-| Repo                      | Config path                | Tab    | Panes                                 |
-| ------------------------- | -------------------------- | ------ | ------------------------------------- |
-| Any repo without override | global `config.toml`       | `dev`  | nvim + agent (right) + lazygit (down) |
-| `~/Projects/my-docs-repo` | `.sessionizer/config.toml` | `docs` | lazygit + pi (right) — no nvim        |
-| `~/Projects/my-app-repo`  | `.sessionizer/config.toml` | `dev`  | nvim + lazygit (right) — no agent     |
-
-**my-docs-repo** — docs/wiki repo, agent-first:
+A docs repo might skip the global `nvim + agent + lazygit` layout and open lazygit with an agent instead:
 
 ```toml
-# ~/Projects/my-docs-repo/.sessionizer/config.toml
+# my-docs-repo/.sessionizer/config.toml
 [layout]
 focus = "docs"
 
@@ -209,38 +201,7 @@ command = "pi"
 └──────────┴─────────┘
 ```
 
-**my-app-repo** — application repo, editor + git only:
-
-```toml
-# ~/Projects/my-app-repo/.sessionizer/config.toml
-[layout]
-focus = "dev"
-
-[tabs.dev]
-label = "dev"
-
-[[tabs.dev.panes]]
-id = "editor"
-title = "nvim"
-command = "nvim"
-
-[[tabs.dev.panes]]
-id = "git"
-from = "editor"
-title = "lazygit"
-split = "right"
-command = "lazygit"
-```
-
-```text
-┌──────────┬─────────┐
-│          │         │
-│   nvim   │ lazygit │
-│          │         │
-└──────────┴─────────┘
-```
-
-Check each `.sessionizer/config.toml` into the repo you want the layout to travel with. Only **new** workspaces pick it up — focusing an existing workspace does not relayout.
+Check `.sessionizer/config.toml` into the repo if you want the layout to travel with the project. Repos without it keep the global default. Only **new** workspaces pick up an override — focusing an existing workspace does not relayout.
 
 ## Example keybindings
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,103 @@ First tab shape:
 - `[[tabs.<name>.panes]]` — panes inside the tab; `from` + `split` (`right` or `down`) define the split tree
 - `command` — exact command a pane runs (`nvim`, `pi`, `claude`, `opencode`, etc.)
 
+### Per-repo layout overrides
+
+A repository can declare its own layout for **new** workspace bootstrap. Put a layout-only config at:
+
+```text
+<project>/.sessionizer/config.toml
+```
+
+When Sessionizer or Worktree creates a new workspace at `cwd`, lookup order is:
+
+1. `<cwd>/.sessionizer/config.toml` — if present, use its `[layout].focus` and `[tabs.*]` (full replacement; no merge with global tabs)
+2. Global `config.toml` — default layout
+
+`[projects].roots` and `[layout].placement` always come from the global config. Repo-local files may include those sections, but they are ignored.
+
+Invalid repo-local config fails with an error that names the file path. Reopening an existing workspace never reapplies layout.
+
+| Event                                       | Layout source                                        |
+| ------------------------------------------- | ---------------------------------------------------- |
+| Sessionizer creates a new project workspace | Repo override at picked `cwd`, else global default   |
+| Worktree creates a new workspace            | Repo override at checkout `cwd`, else global default |
+| Focus or reopen an existing workspace       | No relayout                                          |
+
+#### Example: three layouts side by side
+
+With a global default like the [example layout](#example-layout) above, two repos can override it independently:
+
+| Repo                      | Config path                | Tab    | Panes                                 |
+| ------------------------- | -------------------------- | ------ | ------------------------------------- |
+| Any repo without override | global `config.toml`       | `dev`  | nvim + agent (right) + lazygit (down) |
+| `~/Projects/my-docs-repo` | `.sessionizer/config.toml` | `docs` | lazygit + pi (right) — no nvim        |
+| `~/Projects/my-app-repo`  | `.sessionizer/config.toml` | `dev`  | nvim + lazygit (right) — no agent     |
+
+**my-docs-repo** — docs/wiki repo, agent-first:
+
+```toml
+# ~/Projects/my-docs-repo/.sessionizer/config.toml
+[layout]
+focus = "docs"
+
+[tabs.docs]
+label = "docs"
+
+[[tabs.docs.panes]]
+id = "git"
+title = "lazygit"
+command = "lazygit"
+
+[[tabs.docs.panes]]
+id = "agent"
+from = "git"
+title = "agent"
+split = "right"
+command = "pi"
+```
+
+```text
+┌──────────┬─────────┐
+│          │         │
+│ lazygit  │   pi    │
+│          │         │
+└──────────┴─────────┘
+```
+
+**my-app-repo** — application repo, editor + git only:
+
+```toml
+# ~/Projects/my-app-repo/.sessionizer/config.toml
+[layout]
+focus = "dev"
+
+[tabs.dev]
+label = "dev"
+
+[[tabs.dev.panes]]
+id = "editor"
+title = "nvim"
+command = "nvim"
+
+[[tabs.dev.panes]]
+id = "git"
+from = "editor"
+title = "lazygit"
+split = "right"
+command = "lazygit"
+```
+
+```text
+┌──────────┬─────────┐
+│          │         │
+│   nvim   │ lazygit │
+│          │         │
+└──────────┴─────────┘
+```
+
+Check each `.sessionizer/config.toml` into the repo you want the layout to travel with. Only **new** workspaces pick it up — focusing an existing workspace does not relayout.
+
 ## Example keybindings
 
 ```toml

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "sessionizer"
 name = "Sessionizer"
-version = "0.1.0"
+version = "0.2.0"
 min_herdr_version = "0.7.0"
 description = "Inspired by ThePrimeagen's tmux-sessionizer: fuzzy pickers to open projects and Git worktrees into Herdr workspaces."
 platforms = ["macos"]

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "scripts": {
     "sessionizer": "bun run src/sessionizer.ts",
     "worktree": "bun run src/bin/herdr-worktree.ts",
+    "release": "bun run scripts/release.ts",
+    "release:tag": "bun run scripts/release-tag.ts",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
     "prepare": "husky"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "herdr-plugin-sessionizer",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "description": "Herdr plugin inspired by ThePrimeagen's tmux-sessionizer for fuzzy project and worktree picking",

--- a/scripts/release-tag.ts
+++ b/scripts/release-tag.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 
 import {
   assertReadyToTagRelease,
+  releaseTagName,
   readPackageVersion,
   readPluginManifestVersion,
 } from "../src/release-tag.ts";
@@ -24,6 +25,7 @@ if (!args.version) {
 
 const packagePath = join(cwd, "package.json");
 const manifestPath = join(cwd, "herdr-plugin.toml");
+const tagName = releaseTagName(args.version);
 const packageVersion = readPackageVersion(readFileSync(packagePath, "utf-8"));
 const manifestVersion = readPluginManifestVersion(
   readFileSync(manifestPath, "utf-8")
@@ -34,7 +36,7 @@ const tagExists = runGitAllowFailure([
   "rev-parse",
   "-q",
   "--verify",
-  `refs/tags/${args.version}`,
+  `refs/tags/${tagName}`,
 ]).ok;
 
 assertReadyToTagRelease(args.version, {
@@ -46,17 +48,15 @@ assertReadyToTagRelease(args.version, {
 });
 
 if (args.dryRun) {
-  console.log(
-    `Would create annotated tag ${args.version} from ${currentBranch}`
-  );
-  console.log(`Would push tag ${args.version} to origin`);
+  console.log(`Would create annotated tag ${tagName} from ${currentBranch}`);
+  console.log(`Would push tag ${tagName} to origin`);
   process.exit(0);
 }
 
-runGit(["tag", "-a", args.version, "-m", `Release ${args.version}`]);
-runGit(["push", "origin", args.version]);
+runGit(["tag", "-a", tagName, "-m", `Release ${args.version}`]);
+runGit(["push", "origin", tagName]);
 
-console.log(`Created and pushed annotated tag ${args.version}`);
+console.log(`Created and pushed annotated tag ${tagName}`);
 
 function parseArgs(argv: readonly string[]): CliArgs {
   let version: string | undefined;

--- a/scripts/release-tag.ts
+++ b/scripts/release-tag.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env bun
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  assertReadyToTagRelease,
+  readPackageVersion,
+  readPluginManifestVersion,
+} from "../src/release-tag.ts";
+
+interface CliArgs {
+  version?: string;
+  dryRun: boolean;
+}
+
+const cwd = process.cwd();
+const args = parseArgs(process.argv.slice(2));
+
+if (!args.version) {
+  console.error("Usage: bun run release:tag -- <version> [--dry-run]");
+  process.exit(1);
+}
+
+const packagePath = join(cwd, "package.json");
+const manifestPath = join(cwd, "herdr-plugin.toml");
+const packageVersion = readPackageVersion(readFileSync(packagePath, "utf-8"));
+const manifestVersion = readPluginManifestVersion(
+  readFileSync(manifestPath, "utf-8")
+);
+const currentBranch = runGit(["rev-parse", "--abbrev-ref", "HEAD"]);
+const workingTreeClean = runGit(["status", "--porcelain"]) === "";
+const tagExists = runGitAllowFailure([
+  "rev-parse",
+  "-q",
+  "--verify",
+  `refs/tags/${args.version}`,
+]).ok;
+
+assertReadyToTagRelease(args.version, {
+  currentBranch,
+  workingTreeClean,
+  packageVersion,
+  manifestVersion,
+  tagExists,
+});
+
+if (args.dryRun) {
+  console.log(
+    `Would create annotated tag ${args.version} from ${currentBranch}`
+  );
+  console.log(`Would push tag ${args.version} to origin`);
+  process.exit(0);
+}
+
+runGit(["tag", "-a", args.version, "-m", `Release ${args.version}`]);
+runGit(["push", "origin", args.version]);
+
+console.log(`Created and pushed annotated tag ${args.version}`);
+
+function parseArgs(argv: readonly string[]): CliArgs {
+  let version: string | undefined;
+  let dryRun = false;
+
+  for (const arg of argv) {
+    if (arg === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+
+    if (!version) {
+      version = arg;
+    }
+  }
+
+  return { version, dryRun };
+}
+
+function runGit(args: readonly string[]): string {
+  const result = Bun.spawnSync(["git", ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  if (result.exitCode !== 0) {
+    const stderr = result.stderr.toString().trim();
+    throw new Error(
+      stderr ||
+        `git ${args.join(" ")} failed with exit code ${result.exitCode}.`
+    );
+  }
+
+  return result.stdout.toString().trim();
+}
+
+function runGitAllowFailure(args: readonly string[]): {
+  ok: boolean;
+  output: string;
+} {
+  const result = Bun.spawnSync(["git", ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  return {
+    ok: result.exitCode === 0,
+    output: result.stdout.toString().trim(),
+  };
+}

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env bun
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  assertValidVersion,
+  ensureChangelogRelease,
+  updatePackageVersion,
+  updatePluginManifestVersion,
+} from "../src/release.ts";
+
+interface CliArgs {
+  version?: string;
+  date: string;
+  dryRun: boolean;
+}
+
+const cwd = process.cwd();
+const args = parseArgs(process.argv.slice(2));
+
+if (!args.version) {
+  console.error(
+    "Usage: bun run release -- <version> [--date YYYY-MM-DD] [--dry-run]"
+  );
+  process.exit(1);
+}
+
+assertValidVersion(args.version);
+
+const packagePath = join(cwd, "package.json");
+const manifestPath = join(cwd, "herdr-plugin.toml");
+const changelogPath = join(cwd, "CHANGELOG.md");
+
+const packageNext = updatePackageVersion(
+  readFileSync(packagePath, "utf-8"),
+  args.version
+);
+const manifestNext = updatePluginManifestVersion(
+  readFileSync(manifestPath, "utf-8"),
+  args.version
+);
+const changelogNext = ensureChangelogRelease(
+  readFileSync(changelogPath, "utf-8"),
+  args.version,
+  args.date
+);
+
+if (!args.dryRun) {
+  writeFileSync(packagePath, packageNext, "utf-8");
+  writeFileSync(manifestPath, manifestNext, "utf-8");
+  writeFileSync(changelogPath, changelogNext, "utf-8");
+}
+
+console.log(
+  `${args.dryRun ? "Would update" : "Updated"} package.json -> ${args.version}`
+);
+console.log(
+  `${args.dryRun ? "Would update" : "Updated"} herdr-plugin.toml -> ${args.version}`
+);
+console.log(
+  `${args.dryRun ? "Would ensure" : "Ensured"} CHANGELOG.md contains ## [${args.version}] - ${args.date}`
+);
+
+if (!args.dryRun) {
+  console.log("Next: review CHANGELOG.md, run tests, commit, tag, and push.");
+}
+
+function parseArgs(argv: readonly string[]): CliArgs {
+  let version: string | undefined;
+  let date = new Date().toISOString().slice(0, 10);
+  let dryRun = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg) continue;
+    if (arg === "--date") {
+      date = argv[index + 1] ?? date;
+      index += 1;
+      continue;
+    }
+    if (arg === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (!version) {
+      version = arg;
+    }
+  }
+
+  return { version, date, dryRun };
+}

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  REPO_LAYOUT_CONFIG_RELATIVE,
+  resolveLayoutConfig,
+  resolveRepoLayoutPath,
+  type SessionizerConfig,
+} from "./config.ts";
+
+function globalConfig(): SessionizerConfig {
+  return {
+    projects: { roots: ["/projects"] },
+    layout: { placement: "overlay", focus: "editor" },
+    tabs: [
+      {
+        id: "dev",
+        label: "dev",
+        panes: [
+          { id: "editor", title: "nvim", command: "nvim" },
+          {
+            id: "agent",
+            from: "editor",
+            title: "agent",
+            split: "right",
+            command: "opencode",
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function writeRepoLayout(repoRoot: string, contents: string): string {
+  const configDir = join(repoRoot, ".sessionizer");
+  mkdirSync(configDir, { recursive: true });
+  const configPath = join(configDir, "config.toml");
+  writeFileSync(configPath, contents, "utf-8");
+  return configPath;
+}
+
+describe("resolveLayoutConfig", () => {
+  it("uses repo-local focus and tabs when override exists", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "sessionizer-repo-"));
+    const configPath = writeRepoLayout(
+      repoRoot,
+      [
+        "[layout]",
+        'focus = "wiki"',
+        "",
+        "[tabs.wiki]",
+        'label = "wiki"',
+        "",
+        "[[tabs.wiki.panes]]",
+        'id = "git"',
+        'title = "lazygit"',
+        'command = "lazygit"',
+        "",
+        "[[tabs.wiki.panes]]",
+        'id = "agent"',
+        'from = "git"',
+        'title = "agent"',
+        'split = "right"',
+        'command = "pi"',
+        "",
+      ].join("\n")
+    );
+
+    const resolved = resolveLayoutConfig(repoRoot, globalConfig());
+
+    expect(resolved.layout.placement).toBe("overlay");
+    expect(resolved.layout.focus).toBe("wiki");
+    expect(resolved.tabs).toEqual([
+      {
+        id: "wiki",
+        label: "wiki",
+        panes: [
+          {
+            id: "git",
+            from: undefined,
+            title: "lazygit",
+            split: undefined,
+            command: "lazygit",
+            accept_command_override: false,
+          },
+          {
+            id: "agent",
+            from: "git",
+            title: "agent",
+            split: "right",
+            command: "pi",
+            accept_command_override: false,
+          },
+        ],
+      },
+    ]);
+    expect(resolved.projects).toEqual(globalConfig().projects);
+    expect(configPath).toBe(resolveRepoLayoutPath(repoRoot));
+    expect(REPO_LAYOUT_CONFIG_RELATIVE).toBe(".sessionizer/config.toml");
+  });
+
+  it("falls back to global focus and tabs when override is missing", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "sessionizer-repo-"));
+
+    const resolved = resolveLayoutConfig(repoRoot, globalConfig());
+
+    expect(resolved).toEqual(globalConfig());
+  });
+
+  it("throws with the repo-local path when TOML is invalid", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "sessionizer-repo-"));
+    const configPath = writeRepoLayout(repoRoot, "not valid toml [[[");
+
+    expect(() => resolveLayoutConfig(repoRoot, globalConfig())).toThrow(
+      configPath
+    );
+  });
+
+  it("throws with the repo-local path when focus is missing", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "sessionizer-repo-"));
+    const configPath = writeRepoLayout(
+      repoRoot,
+      [
+        "[tabs.wiki]",
+        'label = "wiki"',
+        "",
+        "[[tabs.wiki.panes]]",
+        'id = "git"',
+        'title = "lazygit"',
+        'command = "lazygit"',
+        "",
+      ].join("\n")
+    );
+
+    expect(() => resolveLayoutConfig(repoRoot, globalConfig())).toThrow(
+      `Repo layout config must define [layout].focus. (${configPath})`
+    );
+  });
+
+  it("throws with the repo-local path when tabs are missing", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "sessionizer-repo-"));
+    const configPath = writeRepoLayout(
+      repoRoot,
+      ["[layout]", 'focus = "wiki"', ""].join("\n")
+    );
+
+    expect(() => resolveLayoutConfig(repoRoot, globalConfig())).toThrow(
+      `Config must define at least one [tabs.<name>] section. (${configPath})`
+    );
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,6 +59,44 @@ export interface SessionizerConfig {
   tabs: TabConfig[];
 }
 
+export const REPO_LAYOUT_CONFIG_RELATIVE = join(".sessionizer", "config.toml");
+
+export function resolveRepoLayoutPath(layoutCwd: string): string {
+  return join(layoutCwd, REPO_LAYOUT_CONFIG_RELATIVE);
+}
+
+export function resolveLayoutConfig(
+  layoutCwd: string,
+  global?: SessionizerConfig
+): SessionizerConfig {
+  const globalConfig = global ?? loadConfig();
+  const repoPath = resolveRepoLayoutPath(layoutCwd);
+
+  if (!existsSync(repoPath)) {
+    return globalConfig;
+  }
+
+  try {
+    const raw = loadRaw(repoPath);
+    const focus = raw?.layout?.focus?.trim();
+    if (!focus) {
+      throw new Error("Repo layout config must define [layout].focus.");
+    }
+
+    return {
+      projects: globalConfig.projects,
+      layout: {
+        placement: globalConfig.layout.placement,
+        focus,
+      },
+      tabs: buildTabs(raw),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`${message} (${repoPath})`);
+  }
+}
+
 export function loadConfig(): SessionizerConfig {
   const pluginConfigDir = resolvePluginConfigDir();
   const pluginConfigPath = join(pluginConfigDir, "config.toml");

--- a/src/config.ts
+++ b/src/config.ts
@@ -208,7 +208,6 @@ function defaultConfigToml(): string {
     'title = "agent"',
     'split = "right"',
     'command = "opencode"',
-    "accept_command_override = true",
     "",
     "[[tabs.dev.panes]]",
     'id = "git"',

--- a/src/release-tag.test.ts
+++ b/src/release-tag.test.ts
@@ -2,9 +2,16 @@ import { describe, expect, it } from "bun:test";
 
 import {
   assertReadyToTagRelease,
+  releaseTagName,
   readPackageVersion,
   readPluginManifestVersion,
 } from "./release-tag.ts";
+
+describe("releaseTagName", () => {
+  it("prefixes release tags with v", () => {
+    expect(releaseTagName("0.2.0")).toBe("v0.2.0");
+  });
+});
 
 describe("readPackageVersion", () => {
   it("reads the package version field", () => {
@@ -75,6 +82,6 @@ describe("assertReadyToTagRelease", () => {
   it("rejects existing tags", () => {
     expect(() =>
       assertReadyToTagRelease("0.2.0", { ...readyState, tagExists: true })
-    ).toThrow("Git tag '0.2.0' already exists.");
+    ).toThrow("Git tag 'v0.2.0' already exists.");
   });
 });

--- a/src/release-tag.test.ts
+++ b/src/release-tag.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  assertReadyToTagRelease,
+  readPackageVersion,
+  readPluginManifestVersion,
+} from "./release-tag.ts";
+
+describe("readPackageVersion", () => {
+  it("reads the package version field", () => {
+    expect(
+      readPackageVersion('{\n  "name": "pkg",\n  "version": "0.2.0"\n}\n')
+    ).toBe("0.2.0");
+  });
+});
+
+describe("readPluginManifestVersion", () => {
+  it("reads the plugin manifest version field", () => {
+    expect(
+      readPluginManifestVersion('id = "sessionizer"\nversion = "0.2.0"\n')
+    ).toBe("0.2.0");
+  });
+});
+
+describe("assertReadyToTagRelease", () => {
+  const readyState = {
+    currentBranch: "main",
+    workingTreeClean: true,
+    packageVersion: "0.2.0",
+    manifestVersion: "0.2.0",
+    tagExists: false,
+  } as const;
+
+  it("accepts a clean main checkout with matching versions", () => {
+    expect(() => assertReadyToTagRelease("0.2.0", readyState)).not.toThrow();
+  });
+
+  it("rejects non-main branches", () => {
+    expect(() =>
+      assertReadyToTagRelease("0.2.0", {
+        ...readyState,
+        currentBranch: "feature/release",
+      })
+    ).toThrow("Release tags must be created from main");
+  });
+
+  it("rejects dirty working trees", () => {
+    expect(() =>
+      assertReadyToTagRelease("0.2.0", {
+        ...readyState,
+        workingTreeClean: false,
+      })
+    ).toThrow("Release tags require a clean git working tree.");
+  });
+
+  it("rejects version mismatches", () => {
+    expect(() =>
+      assertReadyToTagRelease("0.2.0", {
+        ...readyState,
+        packageVersion: "0.1.0",
+      })
+    ).toThrow(
+      "package.json version '0.1.0' does not match requested tag '0.2.0'."
+    );
+    expect(() =>
+      assertReadyToTagRelease("0.2.0", {
+        ...readyState,
+        manifestVersion: "0.1.0",
+      })
+    ).toThrow(
+      "herdr-plugin.toml version '0.1.0' does not match requested tag '0.2.0'."
+    );
+  });
+
+  it("rejects existing tags", () => {
+    expect(() =>
+      assertReadyToTagRelease("0.2.0", { ...readyState, tagExists: true })
+    ).toThrow("Git tag '0.2.0' already exists.");
+  });
+});

--- a/src/release-tag.ts
+++ b/src/release-tag.ts
@@ -1,0 +1,60 @@
+import { assertValidVersion } from "./release.ts";
+
+export interface ReleaseTagState {
+  currentBranch: string;
+  workingTreeClean: boolean;
+  packageVersion: string;
+  manifestVersion: string;
+  tagExists: boolean;
+}
+
+export function readPackageVersion(packageJson: string): string {
+  const parsed = JSON.parse(packageJson) as { version?: unknown };
+  if (typeof parsed.version !== "string" || parsed.version.length === 0) {
+    throw new Error("Could not find package.json version field.");
+  }
+
+  return parsed.version;
+}
+
+export function readPluginManifestVersion(manifest: string): string {
+  const match = manifest.match(/^version = "(.*)"$/m);
+  if (!match?.[1]) {
+    throw new Error("Could not find plugin manifest version field.");
+  }
+
+  return match[1];
+}
+
+export function assertReadyToTagRelease(
+  version: string,
+  state: ReleaseTagState
+): void {
+  assertValidVersion(version);
+
+  if (state.currentBranch !== "main") {
+    throw new Error(
+      `Release tags must be created from main, found '${state.currentBranch}'.`
+    );
+  }
+
+  if (!state.workingTreeClean) {
+    throw new Error("Release tags require a clean git working tree.");
+  }
+
+  if (state.packageVersion !== version) {
+    throw new Error(
+      `package.json version '${state.packageVersion}' does not match requested tag '${version}'.`
+    );
+  }
+
+  if (state.manifestVersion !== version) {
+    throw new Error(
+      `herdr-plugin.toml version '${state.manifestVersion}' does not match requested tag '${version}'.`
+    );
+  }
+
+  if (state.tagExists) {
+    throw new Error(`Git tag '${version}' already exists.`);
+  }
+}

--- a/src/release-tag.ts
+++ b/src/release-tag.ts
@@ -8,6 +8,11 @@ export interface ReleaseTagState {
   tagExists: boolean;
 }
 
+export function releaseTagName(version: string): string {
+  assertValidVersion(version);
+  return `v${version}`;
+}
+
 export function readPackageVersion(packageJson: string): string {
   const parsed = JSON.parse(packageJson) as { version?: unknown };
   if (typeof parsed.version !== "string" || parsed.version.length === 0) {
@@ -30,7 +35,7 @@ export function assertReadyToTagRelease(
   version: string,
   state: ReleaseTagState
 ): void {
-  assertValidVersion(version);
+  const tagName = releaseTagName(version);
 
   if (state.currentBranch !== "main") {
     throw new Error(
@@ -55,6 +60,6 @@ export function assertReadyToTagRelease(
   }
 
   if (state.tagExists) {
-    throw new Error(`Git tag '${version}' already exists.`);
+    throw new Error(`Git tag '${tagName}' already exists.`);
   }
 }

--- a/src/release.test.ts
+++ b/src/release.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  assertValidVersion,
+  ensureChangelogRelease,
+  updatePackageVersion,
+  updatePluginManifestVersion,
+} from "./release.ts";
+
+describe("assertValidVersion", () => {
+  it("accepts semantic versions in x.y.z format", () => {
+    expect(() => assertValidVersion("1.2.3")).not.toThrow();
+  });
+
+  it("rejects non-semver versions", () => {
+    expect(() => assertValidVersion("v1.2.3")).toThrow(
+      "Version must be in x.y.z format"
+    );
+  });
+});
+
+describe("updatePackageVersion", () => {
+  it("updates the package version field", () => {
+    const next = updatePackageVersion(
+      '{\n  "name": "pkg",\n  "version": "0.1.0"\n}\n',
+      "0.2.0"
+    );
+    expect(next).toContain('"version": "0.2.0"');
+  });
+});
+
+describe("updatePluginManifestVersion", () => {
+  it("updates the plugin manifest version field", () => {
+    const next = updatePluginManifestVersion(
+      'id = "sessionizer"\nversion = "0.1.0"\n',
+      "0.2.0"
+    );
+    expect(next).toBe('id = "sessionizer"\nversion = "0.2.0"\n');
+  });
+});
+
+describe("ensureChangelogRelease", () => {
+  it("inserts a new release section after the changelog preamble", () => {
+    const next = ensureChangelogRelease(
+      "# Changelog\n\nAll notable changes.\n\n## [0.1.0] - 2026-06-23\n",
+      "0.2.0",
+      "2026-06-25"
+    );
+    expect(next).toContain("## [0.2.0] - 2026-06-25");
+    expect(next).toContain("### Added");
+  });
+
+  it("does not duplicate an existing release section", () => {
+    const initial = "# Changelog\n\n## [0.2.0] - 2026-06-25\n";
+    expect(ensureChangelogRelease(initial, "0.2.0", "2026-06-25")).toBe(
+      initial
+    );
+  });
+});

--- a/src/release.ts
+++ b/src/release.ts
@@ -1,0 +1,61 @@
+export function assertValidVersion(version: string): void {
+  if (!/^\d+\.\d+\.\d+$/.test(version)) {
+    throw new Error(`Version must be in x.y.z format, received '${version}'.`);
+  }
+}
+
+export function updatePackageVersion(
+  packageJson: string,
+  version: string
+): string {
+  const parsed = JSON.parse(packageJson) as Record<string, unknown>;
+  parsed.version = version;
+  return `${JSON.stringify(parsed, null, 2)}\n`;
+}
+
+export function updatePluginManifestVersion(
+  manifest: string,
+  version: string
+): string {
+  if (!/^version = ".*"$/m.test(manifest)) {
+    throw new Error("Could not find plugin manifest version field.");
+  }
+
+  return manifest.replace(/^version = ".*"$/m, `version = "${version}"`);
+}
+
+export function ensureChangelogRelease(
+  changelog: string,
+  version: string,
+  date: string
+): string {
+  const heading = `## [${version}] - ${date}`;
+  if (
+    changelog.includes(heading) ||
+    new RegExp(`^## \\[${escapeRegex(version)}\\] - `, "m").test(changelog)
+  ) {
+    return changelog;
+  }
+
+  const lines = changelog.split("\n");
+  let insertAt = 0;
+  while (insertAt < lines.length && lines[insertAt] !== "") {
+    insertAt += 1;
+  }
+  while (insertAt < lines.length && lines[insertAt] === "") {
+    insertAt += 1;
+  }
+
+  const section = [heading, "", "### Added", "", "- TBD", ""];
+
+  const next = [
+    ...lines.slice(0, insertAt),
+    ...section,
+    ...lines.slice(insertAt),
+  ].join("\n");
+  return next.endsWith("\n") ? next : `${next}\n`;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/sessionizer.test.ts
+++ b/src/sessionizer.test.ts
@@ -1,22 +1,25 @@
-import { describe, expect, it, mock } from 'bun:test';
+import { describe, expect, it, mock } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
-import type { SessionizerConfig } from './config.ts';
-import type { Workspace } from './client/types.ts';
-import type { LayoutPanes, LayoutTabs } from './layouts/project.ts';
-import { runSessionizer } from './sessionizer.ts';
+import type { SessionizerConfig } from "./config.ts";
+import type { Workspace } from "./client/types.ts";
+import type { LayoutPanes, LayoutTabs } from "./layouts/project.ts";
+import { runSessionizer } from "./sessionizer.ts";
 
 function testConfig(): SessionizerConfig {
   return {
-    projects: { roots: ['/projects'] },
-    layout: { placement: 'overlay', focus: 'assistant' },
+    projects: { roots: ["/projects"] },
+    layout: { placement: "overlay", focus: "assistant" },
     tabs: [],
   };
 }
 
 function testWorkspace(overrides?: Partial<Workspace>): Workspace {
   return {
-    workspace_id: 'ws1',
-    label: 'fieldnotes',
+    workspace_id: "ws1",
+    label: "fieldnotes",
     pane_count: 3,
     tab_count: 2,
     ...overrides,
@@ -25,7 +28,7 @@ function testWorkspace(overrides?: Partial<Workspace>): Workspace {
 
 function testTabs(): LayoutTabs {
   return {
-    create: mock(async () => ({ tab_id: 'ws1:t1', workspace_id: 'ws1' })),
+    create: mock(async () => ({ tab_id: "ws1:t1", workspace_id: "ws1" })),
     rename: mock(async () => {}),
     focus: mock(async () => {}),
   };
@@ -33,14 +36,19 @@ function testTabs(): LayoutTabs {
 
 function testPanes(): LayoutPanes {
   return {
-    split: mock(async () => ({ pane_id: 'ws1-2', terminal_id: 'term-2', workspace_id: 'ws1', tab_id: 'ws1:t1' })),
+    split: mock(async () => ({
+      pane_id: "ws1-2",
+      terminal_id: "term-2",
+      workspace_id: "ws1",
+      tab_id: "ws1:t1",
+    })),
     run: mock(async () => {}),
     rename: mock(async () => {}),
   };
 }
 
-describe('runSessionizer', () => {
-  it('focuses an existing workspace when selected from the first picker', async () => {
+describe("runSessionizer", () => {
+  it("focuses an existing workspace when selected from the first picker", async () => {
     const focus = mock(async () => {});
     const pickRows = mock(async (rows: readonly string[]) => [rows[0]!]);
 
@@ -54,7 +62,7 @@ describe('runSessionizer', () => {
       panes: testPanes(),
       config: testConfig(),
       pickRows,
-      listProjects: mock(() => ['/projects/fieldnotes']),
+      listProjects: mock(() => ["/projects/fieldnotes"]),
       createLayout: mock(async (workspace: Workspace) => workspace),
       logger: { log: mock(() => {}), error: mock(() => {}) },
       exit: (code) => {
@@ -62,25 +70,28 @@ describe('runSessionizer', () => {
       },
     });
 
-    expect(focus).toHaveBeenCalledWith('ws1');
+    expect(focus).toHaveBeenCalledWith("ws1");
     expect(pickRows).toHaveBeenCalledTimes(1);
   });
 
-  it('falls through to the project picker when the existing-session picker is dismissed', async () => {
+  it("falls through to the project picker when the existing-session picker is dismissed", async () => {
     const tabs = testTabs();
     const panes = testPanes();
-    const create = mock(async ({ cwd, label }: { cwd: string; label: string }) =>
-      testWorkspace({ cwd, label, workspace_id: 'ws-project' }),
+    const create = mock(
+      async ({ cwd, label }: { cwd: string; label: string }) =>
+        testWorkspace({ cwd, label, workspace_id: "ws-project" })
     );
     const focus = mock(async () => {});
     const createLayout = mock(async (workspace: Workspace) => workspace);
-    const pickRows = mock(async (_rows: readonly string[], options?: { prompt?: string }) => {
-      if (options?.prompt === 'Switch session (Esc for new): ') {
-        return null;
-      }
+    const pickRows = mock(
+      async (_rows: readonly string[], options?: { prompt?: string }) => {
+        if (options?.prompt === "Switch session (Esc for new): ") {
+          return null;
+        }
 
-      return ['/projects/fieldnotes'];
-    });
+        return ["/projects/fieldnotes"];
+      }
+    );
 
     await runSessionizer({
       workspaces: {
@@ -92,7 +103,7 @@ describe('runSessionizer', () => {
       panes,
       config: testConfig(),
       pickRows,
-      listProjects: mock(() => ['/projects/fieldnotes']),
+      listProjects: mock(() => ["/projects/fieldnotes"]),
       createLayout,
       logger: { log: mock(() => {}), error: mock(() => {}) },
       exit: (code) => {
@@ -102,21 +113,25 @@ describe('runSessionizer', () => {
 
     expect(pickRows).toHaveBeenCalledTimes(2);
     expect(create).toHaveBeenCalledWith({
-      cwd: '/projects/fieldnotes',
-      label: 'fieldnotes',
+      cwd: "/projects/fieldnotes",
+      label: "fieldnotes",
       focus: false,
     });
     expect(createLayout).toHaveBeenCalledWith(
-      testWorkspace({ cwd: '/projects/fieldnotes', label: 'fieldnotes', workspace_id: 'ws-project' }),
-      '/projects/fieldnotes',
+      testWorkspace({
+        cwd: "/projects/fieldnotes",
+        label: "fieldnotes",
+        workspace_id: "ws-project",
+      }),
+      "/projects/fieldnotes",
       testConfig(),
       tabs,
-      panes,
+      panes
     );
-    expect(focus).toHaveBeenCalledWith('ws-project');
+    expect(focus).toHaveBeenCalledWith("ws-project");
   });
 
-  it('exits with an error when no projects are found', async () => {
+  it("exits with an error when no projects are found", async () => {
     const error = mock(() => {});
 
     await expect(
@@ -136,18 +151,26 @@ describe('runSessionizer', () => {
         exit: (code) => {
           throw new Error(`exit ${code}`);
         },
-      }),
-    ).rejects.toThrow('exit 1');
+      })
+    ).rejects.toThrow("exit 1");
 
-    expect(error).toHaveBeenCalledWith('No projects found in configured directories.');
+    expect(error).toHaveBeenCalledWith(
+      "No projects found in configured directories."
+    );
   });
 
-  it('creates, lays out, and focuses a new workspace from the project picker', async () => {
+  it("creates, lays out, and focuses a new workspace from the project picker", async () => {
     const tabs = testTabs();
     const panes = testPanes();
-    const workspace = testWorkspace({ cwd: '/projects/herdr-sessionizer', label: 'herdr-sessionizer', workspace_id: 'ws-new' });
+    const workspace = testWorkspace({
+      cwd: "/projects/herdr-sessionizer",
+      label: "herdr-sessionizer",
+      workspace_id: "ws-new",
+    });
     const create = mock(async () => workspace);
-    const createLayout = mock(async (createdWorkspace: Workspace) => createdWorkspace);
+    const createLayout = mock(
+      async (createdWorkspace: Workspace) => createdWorkspace
+    );
     const focus = mock(async () => {});
     const log = mock(() => {});
 
@@ -160,14 +183,16 @@ describe('runSessionizer', () => {
       tabs,
       panes,
       config: testConfig(),
-      pickRows: mock(async (_rows: readonly string[], options?: { prompt?: string }) => {
-        if (options?.prompt === 'Switch session (Esc for new): ') {
-          return null;
-        }
+      pickRows: mock(
+        async (_rows: readonly string[], options?: { prompt?: string }) => {
+          if (options?.prompt === "Switch session (Esc for new): ") {
+            return null;
+          }
 
-        return ['/projects/herdr-sessionizer'];
-      }),
-      listProjects: mock(() => ['/projects/herdr-sessionizer']),
+          return ["/projects/herdr-sessionizer"];
+        }
+      ),
+      listProjects: mock(() => ["/projects/herdr-sessionizer"]),
       createLayout,
       logger: { log, error: mock(() => {}) },
       exit: (code) => {
@@ -176,12 +201,107 @@ describe('runSessionizer', () => {
     });
 
     expect(create).toHaveBeenCalledWith({
-      cwd: '/projects/herdr-sessionizer',
-      label: 'herdr-sessionizer',
+      cwd: "/projects/herdr-sessionizer",
+      label: "herdr-sessionizer",
       focus: false,
     });
-    expect(createLayout).toHaveBeenCalledWith(workspace, '/projects/herdr-sessionizer', testConfig(), tabs, panes);
-    expect(focus).toHaveBeenCalledWith('ws-new');
-    expect(log).toHaveBeenCalledWith("✓ workspace 'herdr-sessionizer' created and focused (ws-new)");
+    expect(createLayout).toHaveBeenCalledWith(
+      workspace,
+      "/projects/herdr-sessionizer",
+      testConfig(),
+      tabs,
+      panes
+    );
+    expect(focus).toHaveBeenCalledWith("ws-new");
+    expect(log).toHaveBeenCalledWith(
+      "✓ workspace 'herdr-sessionizer' created and focused (ws-new)"
+    );
+  });
+
+  it("applies a repo-local layout override when creating a new workspace", async () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), "sessionizer-project-"));
+    mkdirSync(join(projectRoot, ".sessionizer"), { recursive: true });
+    writeFileSync(
+      join(projectRoot, ".sessionizer", "config.toml"),
+      [
+        "[layout]",
+        'focus = "wiki"',
+        "",
+        "[tabs.wiki]",
+        'label = "wiki"',
+        "",
+        "[[tabs.wiki.panes]]",
+        'id = "git"',
+        'title = "lazygit"',
+        'command = "lazygit"',
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const tabs = testTabs();
+    const panes = testPanes();
+    const workspace = testWorkspace({
+      cwd: projectRoot,
+      label: "repo-override",
+      workspace_id: "ws-override",
+    });
+    const createLayout = mock(
+      async (createdWorkspace: Workspace) => createdWorkspace
+    );
+    const config = testConfig();
+
+    await runSessionizer({
+      workspaces: {
+        list: mock(async () => []),
+        create: mock(async () => workspace),
+        focus: mock(async () => {}),
+      },
+      tabs,
+      panes,
+      config,
+      pickRows: mock(
+        async (_rows: readonly string[], options?: { prompt?: string }) => {
+          if (options?.prompt === "Switch session (Esc for new): ") {
+            return null;
+          }
+
+          return [projectRoot];
+        }
+      ),
+      listProjects: mock(() => [projectRoot]),
+      createLayout,
+      logger: { log: mock(() => {}), error: mock(() => {}) },
+      exit: (code) => {
+        throw new Error(`unexpected exit ${code}`);
+      },
+    });
+
+    expect(createLayout).toHaveBeenCalledWith(
+      workspace,
+      projectRoot,
+      {
+        ...config,
+        layout: { placement: "overlay", focus: "wiki" },
+        tabs: [
+          {
+            id: "wiki",
+            label: "wiki",
+            panes: [
+              {
+                id: "git",
+                from: undefined,
+                title: "lazygit",
+                split: undefined,
+                command: "lazygit",
+                accept_command_override: false,
+              },
+            ],
+          },
+        ],
+      },
+      tabs,
+      panes
+    );
   });
 });

--- a/src/sessionizer.ts
+++ b/src/sessionizer.ts
@@ -1,31 +1,39 @@
-import { basename } from 'node:path';
+import { basename } from "node:path";
 
-import { listProjects, sanitizeName } from './discovery.ts';
+import { listProjects, sanitizeName } from "./discovery.ts";
 
-import type { Workspace } from './client/types.ts';
-import { Herdr } from './client/herdr.ts';
-import type { SessionizerConfig } from './config.ts';
-import { loadConfig } from './config.ts';
-import { createProjectLayout, type LayoutPanes, type LayoutTabs } from './layouts/project.ts';
-import { Panes } from './ops/panes.ts';
-import { Tabs } from './ops/tabs.ts';
-import { Workspaces } from './ops/workspaces.ts';
-import { pick, type PickOptions } from './ui/fzf.ts';
-import { PROJECT_PREVIEW, WORKSPACE_PREVIEW } from './ui/previews.ts';
+import type { Workspace } from "./client/types.ts";
+import { Herdr } from "./client/herdr.ts";
+import type { SessionizerConfig } from "./config.ts";
+import { loadConfig, resolveLayoutConfig } from "./config.ts";
+import {
+  createProjectLayout,
+  type LayoutPanes,
+  type LayoutTabs,
+} from "./layouts/project.ts";
+import { Panes } from "./ops/panes.ts";
+import { Tabs } from "./ops/tabs.ts";
+import { Workspaces } from "./ops/workspaces.ts";
+import { pick, type PickOptions } from "./ui/fzf.ts";
+import { PROJECT_PREVIEW, WORKSPACE_PREVIEW } from "./ui/previews.ts";
 
-const WORKSPACE_ROW_DELIMITER = '\t';
+const WORKSPACE_ROW_DELIMITER = "\t";
 
 type LayoutApplier = (
   workspace: Workspace,
   cwd: string,
   config: SessionizerConfig,
   tabs: LayoutTabs,
-  panes: LayoutPanes,
+  panes: LayoutPanes
 ) => Promise<Workspace>;
 
 interface SessionizerWorkspaceRuntime {
   list(): Promise<Workspace[]>;
-  create(options: { cwd: string; label: string; focus?: boolean }): Promise<Workspace>;
+  create(options: {
+    cwd: string;
+    label: string;
+    focus?: boolean;
+  }): Promise<Workspace>;
   focus(workspaceId: string): Promise<void>;
 }
 
@@ -34,10 +42,13 @@ interface SessionizerRuntime {
   tabs: LayoutTabs;
   panes: LayoutPanes;
   config: SessionizerConfig;
-  pickRows: (rows: readonly string[], options?: PickOptions) => Promise<string[] | null>;
+  pickRows: (
+    rows: readonly string[],
+    options?: PickOptions
+  ) => Promise<string[] | null>;
   listProjects: (roots: string[]) => string[];
   createLayout: LayoutApplier;
-  logger: Pick<typeof console, 'log' | 'error'>;
+  logger: Pick<typeof console, "log" | "error">;
   exit: (code: number) => never;
 }
 
@@ -64,17 +75,22 @@ function extractWorkspaceId(row: string): string {
   return row.split(WORKSPACE_ROW_DELIMITER)[0] ?? row;
 }
 
-export async function runSessionizer(runtime: SessionizerRuntime = createRuntime()): Promise<void> {
+export async function runSessionizer(
+  runtime: SessionizerRuntime = createRuntime()
+): Promise<void> {
   const { workspaces, tabs, panes, config } = runtime;
 
-  const existing = await runtime.pickRows((await workspaces.list()).map(workspaceRow), {
-    prompt: 'Switch session (Esc for new): ',
-    header: '↑↓ navigate, Enter select, Esc → new project',
-    delimiter: WORKSPACE_ROW_DELIMITER,
-    withNth: '2',
-    preview: WORKSPACE_PREVIEW,
-    previewWindow: 'right:50%',
-  });
+  const existing = await runtime.pickRows(
+    (await workspaces.list()).map(workspaceRow),
+    {
+      prompt: "Switch session (Esc for new): ",
+      header: "↑↓ navigate, Enter select, Esc → new project",
+      delimiter: WORKSPACE_ROW_DELIMITER,
+      withNth: "2",
+      preview: WORKSPACE_PREVIEW,
+      previewWindow: "right:50%",
+    }
+  );
 
   if (existing && existing.length > 0) {
     await workspaces.focus(extractWorkspaceId(existing[0]!));
@@ -83,28 +99,35 @@ export async function runSessionizer(runtime: SessionizerRuntime = createRuntime
 
   const projects = runtime.listProjects(config.projects.roots);
   if (projects.length === 0) {
-    runtime.logger.error('No projects found in configured directories.');
+    runtime.logger.error("No projects found in configured directories.");
     runtime.exit(1);
   }
 
   const selected = await runtime.pickRows(projects, {
-    prompt: 'Project: ',
-    header: 'Select a project to create a workspace',
+    prompt: "Project: ",
+    header: "Select a project to create a workspace",
     preview: PROJECT_PREVIEW,
-    previewWindow: 'right:50%',
+    previewWindow: "right:50%",
   });
 
   if (!selected || selected.length === 0) return;
 
   const project = selected[0]!;
-  const projectName = project.split('/').pop() ?? project;
+  const projectName = project.split("/").pop() ?? project;
   const label = sanitizeName(projectName);
-  const workspace = await workspaces.create({ cwd: project, label, focus: false });
+  const workspace = await workspaces.create({
+    cwd: project,
+    label,
+    focus: false,
+  });
 
-  await runtime.createLayout(workspace, project, config, tabs, panes);
+  const layoutConfig = resolveLayoutConfig(project, config);
+  await runtime.createLayout(workspace, project, layoutConfig, tabs, panes);
   await workspaces.focus(workspace.workspace_id);
 
-  runtime.logger.log(`✓ workspace '${label}' created and focused (${workspace.workspace_id})`);
+  runtime.logger.log(
+    `✓ workspace '${label}' created and focused (${workspace.workspace_id})`
+  );
 }
 
 function workspaceName(workspace: Workspace): string {
@@ -134,15 +157,20 @@ function workspaceSummary(workspace: Workspace): string {
 }
 
 function workspacePath(workspace: Workspace): string | undefined {
-  return workspace.cwd ?? workspace.worktree?.checkout_path ?? workspace.worktree?.repo_root ?? workspace.worktree?.path;
+  return (
+    workspace.cwd ??
+    workspace.worktree?.checkout_path ??
+    workspace.worktree?.repo_root ??
+    workspace.worktree?.path
+  );
 }
 
 function rowField(value: unknown): string {
-  if (typeof value !== 'string') {
-    return '';
+  if (typeof value !== "string") {
+    return "";
   }
 
-  return value.replaceAll('\t', ' ').replaceAll('\n', ' ').trim();
+  return value.replaceAll("\t", " ").replaceAll("\n", " ").trim();
 }
 
 function createRuntime(): SessionizerRuntime {

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -1,19 +1,19 @@
-import { listProjects, sanitizeName, normalizePath } from './discovery.ts';
+import { listProjects, sanitizeName, normalizePath } from "./discovery.ts";
 
-import { Herdr } from './client/herdr.ts';
-import { HerdrError } from './client/errors.ts';
-import type { SessionizerConfig } from './config.ts';
-import type { Workspace } from './client/types.ts';
-import { loadConfig } from './config.ts';
-import { createProjectLayout } from './layouts/project.ts';
-import { Panes } from './ops/panes.ts';
-import { Tabs } from './ops/tabs.ts';
-import { Workspaces } from './ops/workspaces.ts';
-import { Worktrees } from './ops/worktrees.ts';
-import { pick } from './ui/fzf.ts';
-import { promptText } from './ui/prompt.ts';
-import { attachExistingBranchWorktree } from './worktree-branch-fallback.ts';
-import { WorktreeResolver } from './worktree-resolver.ts';
+import { Herdr } from "./client/herdr.ts";
+import { HerdrError } from "./client/errors.ts";
+import type { SessionizerConfig } from "./config.ts";
+import type { Workspace } from "./client/types.ts";
+import { loadConfig, resolveLayoutConfig } from "./config.ts";
+import { createProjectLayout } from "./layouts/project.ts";
+import { Panes } from "./ops/panes.ts";
+import { Tabs } from "./ops/tabs.ts";
+import { Workspaces } from "./ops/workspaces.ts";
+import { Worktrees } from "./ops/worktrees.ts";
+import { pick } from "./ui/fzf.ts";
+import { promptText } from "./ui/prompt.ts";
+import { attachExistingBranchWorktree } from "./worktree-branch-fallback.ts";
+import { WorktreeResolver } from "./worktree-resolver.ts";
 
 interface CliArgs {
   project?: string;
@@ -30,7 +30,7 @@ type LayoutApplier = (
   options?: {
     commandOverride?: string;
     branch?: string;
-  },
+  }
 ) => Promise<Workspace>;
 
 interface WorktreeWorkspaceRuntime {
@@ -40,8 +40,8 @@ interface WorktreeWorkspaceRuntime {
 }
 
 interface WorktreeServiceRuntime {
-  open: Worktrees['open'];
-  create: Worktrees['create'];
+  open: Worktrees["open"];
+  create: Worktrees["create"];
 }
 
 interface WorktreeRuntime {
@@ -50,18 +50,18 @@ interface WorktreeRuntime {
   tabs: unknown;
   panes: unknown;
   config: SessionizerConfig;
-  resolver: Pick<WorktreeResolver, 'resolveExisting'>;
+  resolver: Pick<WorktreeResolver, "resolveExisting">;
   createLayout: LayoutApplier;
   pickProject: typeof pick;
   promptBranch: () => Promise<string>;
   attachExistingBranch: (project: string, branch: string) => Promise<string>;
-  logger: Pick<typeof console, 'log' | 'error'>;
+  logger: Pick<typeof console, "log" | "error">;
   exit: (code: number) => never;
 }
 
 export async function runWorktree(
   argv: readonly string[] = process.argv.slice(2),
-  runtime: WorktreeRuntime = createRuntime(),
+  runtime: WorktreeRuntime = createRuntime()
 ): Promise<void> {
   const args = parseArgs(argv);
   const { worktrees, workspaces, tabs, panes, config, resolver } = runtime;
@@ -71,19 +71,21 @@ export async function runWorktree(
   const command = args.command;
 
   if ((project && !branch) || (!project && branch)) {
-    throw new Error('Use both project and branch together, or use neither for interactive mode.');
+    throw new Error(
+      "Use both project and branch together, or use neither for interactive mode."
+    );
   }
 
   if (!project && !branch) {
     const projects = listProjects(config.projects.roots);
     if (projects.length === 0) {
-      runtime.logger.error('No projects found in configured directories.');
+      runtime.logger.error("No projects found in configured directories.");
       runtime.exit(1);
     }
 
     const selected = await runtime.pickProject(projects, {
-      prompt: 'Base project for worktree: ',
-      header: 'Select a repo to spin off a worktree workspace',
+      prompt: "Base project for worktree: ",
+      header: "Select a repo to spin off a worktree workspace",
     });
 
     if (!selected || selected.length === 0) return;
@@ -94,7 +96,7 @@ export async function runWorktree(
 
   if (!project || !branch) return;
   if (/\s/.test(branch)) {
-    throw new Error('Branch name cannot contain spaces.');
+    throw new Error("Branch name cannot contain spaces.");
   }
 
   const label = sanitizeName(branch);
@@ -125,7 +127,11 @@ export async function runWorktree(
   } catch (error) {
     const herdrError = asHerdrError(error);
     if (!herdrError) throw error;
-    const existing = await resolver.resolveExisting({ project, branch, error: herdrError });
+    const existing = await resolver.resolveExisting({
+      project,
+      branch,
+      error: herdrError,
+    });
     if (existing) {
       await worktrees.open({
         workspaceId: repoWorkspaceId,
@@ -133,7 +139,9 @@ export async function runWorktree(
         path: existing.path,
         focus: true,
       });
-      runtime.logger.log(`✓ opened existing worktree path '${existing.path}' for '${branch}'`);
+      runtime.logger.log(
+        `✓ opened existing worktree path '${existing.path}' for '${branch}'`
+      );
       return;
     }
     if (!isDuplicateBranchError(herdrError)) throw herdrError;
@@ -148,27 +156,46 @@ export async function runWorktree(
     });
     const reopenedWorkspace = reopened.workspace;
     if (!reopenedWorkspace) {
-      throw new Error(`worktree open succeeded but no workspace was returned for '${path}'`);
+      throw new Error(
+        `worktree open succeeded but no workspace was returned for '${path}'`
+      );
     }
 
-    const layoutCwd = await resolveLayoutCwd(workspaces, reopenedWorkspace, reopened.worktreePath ?? path);
-    await runtime.createLayout(reopenedWorkspace, layoutCwd, config, tabs, panes, {
-      commandOverride: command,
-      branch,
-    });
+    const layoutCwd = await resolveLayoutCwd(
+      workspaces,
+      reopenedWorkspace,
+      reopened.worktreePath ?? path
+    );
+    const layoutConfig = resolveLayoutConfig(layoutCwd, config);
+    await runtime.createLayout(
+      reopenedWorkspace,
+      layoutCwd,
+      layoutConfig,
+      tabs,
+      panes,
+      {
+        commandOverride: command,
+        branch,
+      }
+    );
     await workspaces.focus(reopenedWorkspace.workspace_id);
-    runtime.logger.log(`✓ worktree '${branch}' created and focused (${reopenedWorkspace.workspace_id})`);
+    runtime.logger.log(
+      `✓ worktree '${branch}' created and focused (${reopenedWorkspace.workspace_id})`
+    );
     return;
   }
 
   const layoutCwd = await resolveLayoutCwd(workspaces, workspace, project);
-  await runtime.createLayout(workspace, layoutCwd, config, tabs, panes, {
+  const layoutConfig = resolveLayoutConfig(layoutCwd, config);
+  await runtime.createLayout(workspace, layoutCwd, layoutConfig, tabs, panes, {
     commandOverride: command,
     branch,
   });
   await workspaces.focus(workspace.workspace_id);
 
-  runtime.logger.log(`✓ worktree '${branch}' created and focused (${workspace.workspace_id})`);
+  runtime.logger.log(
+    `✓ worktree '${branch}' created and focused (${workspace.workspace_id})`
+  );
 }
 
 function parseArgs(argv: readonly string[]): CliArgs {
@@ -178,17 +205,17 @@ function parseArgs(argv: readonly string[]): CliArgs {
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
-    if (arg === '--project' || arg === '-p') {
+    if (arg === "--project" || arg === "-p") {
       project = argv[index + 1];
       index += 1;
       continue;
     }
-    if (arg === '--branch' || arg === '-b') {
+    if (arg === "--branch" || arg === "-b") {
       branch = argv[index + 1];
       index += 1;
       continue;
     }
-    if (arg === '--command' || arg === '-c' || arg === '--context') {
+    if (arg === "--command" || arg === "-c" || arg === "--context") {
       command = argv[index + 1];
       index += 1;
     }
@@ -199,13 +226,13 @@ function parseArgs(argv: readonly string[]): CliArgs {
 
 async function promptBranchName(): Promise<string> {
   while (true) {
-    const value = await promptText('Branch name: ');
+    const value = await promptText("Branch name: ");
     if (!value) {
-      console.error('Branch name cannot be empty.');
+      console.error("Branch name cannot be empty.");
       continue;
     }
     if (/\s/.test(value)) {
-      console.error('Branch name cannot contain spaces.');
+      console.error("Branch name cannot contain spaces.");
       continue;
     }
     return value;
@@ -223,7 +250,14 @@ function createRuntime(): WorktreeRuntime {
     config: loadConfig(),
     resolver: new WorktreeResolver(),
     createLayout: (workspace, cwd, config, tabs, panes, options) =>
-      createProjectLayout(workspace, cwd, config, tabs as Tabs, panes as Panes, options),
+      createProjectLayout(
+        workspace,
+        cwd,
+        config,
+        tabs as Tabs,
+        panes as Panes,
+        options
+      ),
     pickProject: pick,
     promptBranch: promptBranchName,
     attachExistingBranch: attachExistingBranchWorktree,
@@ -232,33 +266,45 @@ function createRuntime(): WorktreeRuntime {
   };
 }
 
-
-
-function findRepoWorkspaceId(workspaces: Workspace[], projectPath: string): string | undefined {
+function findRepoWorkspaceId(
+  workspaces: Workspace[],
+  projectPath: string
+): string | undefined {
   const normalizedProject = normalizePath(projectPath);
-  return workspaces.find((workspace) => !workspace.worktree && normalizePath(workspace.cwd) === normalizedProject)?.workspace_id;
+  return workspaces.find(
+    (workspace) =>
+      !workspace.worktree && normalizePath(workspace.cwd) === normalizedProject
+  )?.workspace_id;
 }
 
-function worktreeCheckoutPath(workspace: Workspace | undefined): string | undefined {
+function worktreeCheckoutPath(
+  workspace: Workspace | undefined
+): string | undefined {
   return workspace?.worktree?.checkout_path ?? workspace?.worktree?.path;
 }
 
 async function resolveLayoutCwd(
-  workspaces: Pick<WorktreeWorkspaceRuntime, 'get'>,
+  workspaces: Pick<WorktreeWorkspaceRuntime, "get">,
   workspace: Workspace,
-  fallback: string,
+  fallback: string
 ): Promise<string> {
   const current = await workspaces.get(workspace.workspace_id);
-  return worktreeCheckoutPath(current) ?? current?.cwd ?? worktreeCheckoutPath(workspace) ?? workspace.cwd ?? fallback;
+  return (
+    worktreeCheckoutPath(current) ??
+    current?.cwd ??
+    worktreeCheckoutPath(workspace) ??
+    workspace.cwd ??
+    fallback
+  );
 }
 
 function asHerdrError(error: unknown): HerdrError | undefined {
   if (error instanceof HerdrError) return error;
   if (
-    typeof error === 'object' &&
+    typeof error === "object" &&
     error !== null &&
-    'stderr' in error &&
-    typeof (error as { stderr: unknown }).stderr === 'string'
+    "stderr" in error &&
+    typeof (error as { stderr: unknown }).stderr === "string"
   ) {
     return error as HerdrError;
   }
@@ -266,5 +312,5 @@ function asHerdrError(error: unknown): HerdrError | undefined {
 }
 
 function isDuplicateBranchError(error: HerdrError): boolean {
-  return error.stderr.includes('a branch named');
+  return error.stderr.includes("a branch named");
 }


### PR DESCRIPTION
## Summary

Adds optional per-repo layout overrides at `<cwd>/.sessionizer/config.toml`. When Sessionizer or Worktree bootstraps a **new** workspace, it uses the repo-local `[layout].focus` and `[tabs.*]` if present; otherwise it falls back to the global plugin config.

`[projects].roots` and `[layout].placement` always come from global config. Invalid repo-local config fails with an error that names the file path. Reopening an existing workspace does not relayout (ADR-0001).

Closes #12

## Changes

- `resolveLayoutConfig()` in `src/config.ts` — lookup + validation
- Wired into `sessionizer.ts` and `worktree.ts` on new-bootstrap paths only
- Unit tests for override, fallback, and error cases
- README section with generic examples (`my-docs-repo`, `my-app-repo`)

## Test plan

- [x] `bun run typecheck`
- [x] `bun test` (81 passing)
- [ ] Manual: create new workspace for repo with `.sessionizer/config.toml` — distinct layout
- [ ] Manual: create new workspace for repo without override — global default
- [ ] Manual: reopen existing workspace — no relayout