### PR TITLE
Add git repo project discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Optional: [bat](https://github.com/sharkdp/bat) for richer `README.md` previews 
 ## Setup
 
 ```sh
-herdr plugin install andrewchng/herdr-sessionizer --yes
+herdr plugin install MMSs/herdr-sessionizer --yes
 herdr plugin config-dir sessionizer
 ```
 
@@ -104,9 +104,9 @@ command = "sessionizer.worktree-open"
 description = "open worktree workspace"
 ```
 
-**Sessionizer** lists existing workspaces plus repos under `projects.roots`. Pick a workspace to focus it, or pick a project to create a new workspace with your configured layout.
+**Sessionizer** lists existing workspaces plus projects under `projects.roots`. Pick a workspace to focus it, or pick a project to create a new workspace with your configured layout.
 
-**Worktree** lists base repos under `projects.roots`, then shows a branch/worktree picker with previews when there are existing choices:
+**Worktree** lists base projects under `projects.roots`, then shows a branch/worktree picker with previews when there are existing choices:
 
 | Selection                   | Result                                            |
 | --------------------------- | ------------------------------------------------- |
@@ -125,7 +125,7 @@ When Sessionizer **creates** a new project or worktree workspace, it applies the
 
 Created automatically on first run if missing. It controls:
 
-- **`[projects]`** — parent folders the `fzf` pickers scan for repos
+- **`[projects]`** — parent folders and discovery mode used by the `fzf` pickers
 - **`[layout]`, `[tabs.*]` + `[[tabs.*.panes]]`** — the tabs, splits, per-split ratios, commands, and final focus for newly created workspaces
 
 If you want an agent to help edit either the global config or a repo-local override, see [Agent skill](#agent-skill).
@@ -135,6 +135,8 @@ If you want an agent to help edit either the global config or a repo-local overr
 ```toml
 [projects]
 roots = ["~/Projects", "~/Workspace"]
+git_only = false
+depth = 1
 
 [layout]
 placement = "overlay"
@@ -198,6 +200,8 @@ Second tab shape:
 ```
 
 - `[projects].roots` — parent folders scanned by both pickers
+- `[projects].git_only` — `false` lists immediate child folders; `true` recursively returns only directories with `.git` metadata
+- `[projects].depth` — maximum levels below each root to scan when `git_only = true`; `1` means immediate children
 - `[layout].placement` — how plugin panes open (`overlay` or `split`)
 - `[layout].focus` — which tab or pane to focus after layout bootstrap
 - `[tabs.<name>]` — one Herdr tab to create per section

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Optional: [bat](https://github.com/sharkdp/bat) for richer `README.md` previews 
 ## Setup
 
 ```sh
-herdr plugin install MMSs/herdr-sessionizer --yes
+herdr plugin install andrewchng/herdr-sessionizer --yes
 herdr plugin config-dir sessionizer
 ```
 
@@ -104,9 +104,9 @@ command = "sessionizer.worktree-open"
 description = "open worktree workspace"
 ```
 
-**Sessionizer** lists existing workspaces plus projects under `projects.roots`. Pick a workspace to focus it, or pick a project to create a new workspace with your configured layout.
+**Sessionizer** lists existing workspaces plus repos under `projects.roots`. Pick a workspace to focus it, or pick a project to create a new workspace with your configured layout.
 
-**Worktree** lists base projects under `projects.roots`, then shows a branch/worktree picker with previews when there are existing choices:
+**Worktree** lists base repos under `projects.roots`, then shows a branch/worktree picker with previews when there are existing choices:
 
 | Selection                   | Result                                            |
 | --------------------------- | ------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ When Sessionizer **creates** a new project or worktree workspace, it applies the
 
 Created automatically on first run if missing. It controls:
 
-- **`[projects]`** — parent folders and discovery mode used by the `fzf` pickers
+- **`[projects]`** — parent folders the `fzf` pickers scan for repos
 - **`[layout]`, `[tabs.*]` + `[[tabs.*.panes]]`** — the tabs, splits, per-split ratios, commands, and final focus for newly created workspaces
 
 If you want an agent to help edit either the global config or a repo-local override, see [Agent skill](#agent-skill).

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import {
+  loadConfig,
   REPO_LAYOUT_CONFIG_RELATIVE,
   resolveLayoutConfig,
   resolveRepoLayoutPath,
@@ -12,7 +13,7 @@ import {
 
 function globalConfig(): SessionizerConfig {
   return {
-    projects: { roots: ["/projects"] },
+    projects: { roots: ["/projects"], git_only: false, depth: 1 },
     layout: { placement: "overlay", focus: "editor" },
     tabs: [
       {
@@ -40,6 +41,78 @@ function writeRepoLayout(repoRoot: string, contents: string): string {
   writeFileSync(configPath, contents, "utf-8");
   return configPath;
 }
+
+function minimalGlobalConfig(projects: string[]): string {
+  return [
+    "[projects]",
+    ...projects,
+    "",
+    "[layout]",
+    'placement = "overlay"',
+    'focus = "editor"',
+    "",
+    "[tabs.dev]",
+    'label = "dev"',
+    "",
+    "[[tabs.dev.panes]]",
+    'id = "editor"',
+    'title = "nvim"',
+    'command = "nvim"',
+    "",
+  ].join("\n");
+}
+
+function withPluginConfigDir<T>(callback: (dir: string) => T): T {
+  const previous = process.env.HERDR_PLUGIN_CONFIG_DIR;
+  const dir = mkdtempSync(join(tmpdir(), "sessionizer-config-"));
+  process.env.HERDR_PLUGIN_CONFIG_DIR = dir;
+
+  try {
+    return callback(dir);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.HERDR_PLUGIN_CONFIG_DIR;
+    } else {
+      process.env.HERDR_PLUGIN_CONFIG_DIR = previous;
+    }
+  }
+}
+
+describe("loadConfig", () => {
+  it("defaults project discovery to non-git immediate folders", () => {
+    withPluginConfigDir((dir) => {
+      writeFileSync(
+        join(dir, "config.toml"),
+        minimalGlobalConfig(['roots = ["~/Projects"]']),
+        "utf-8"
+      );
+
+      const config = loadConfig();
+
+      expect(config.projects.git_only).toBe(false);
+      expect(config.projects.depth).toBe(1);
+    });
+  });
+
+  it("loads git_only before depth from project config", () => {
+    withPluginConfigDir((dir) => {
+      writeFileSync(
+        join(dir, "config.toml"),
+        minimalGlobalConfig([
+          'roots = ["~/Projects"]',
+          "git_only = true",
+          "depth = 3",
+        ]),
+        "utf-8"
+      );
+
+      const config = loadConfig();
+
+      expect(config.projects.git_only).toBe(true);
+      expect(config.projects.depth).toBe(3);
+    });
+  });
+});
 
 describe("resolveLayoutConfig", () => {
   it("uses repo-local focus and tabs when override exists", () => {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -26,7 +26,11 @@ interface RawTabConfig {
 }
 
 interface RawConfig {
-  projects?: { roots?: string[] };
+  projects?: {
+    roots?: string[];
+    git_only?: boolean;
+    depth?: unknown;
+  };
   layout?: {
     placement?: string;
     focus?: string;
@@ -53,6 +57,8 @@ export interface TabConfig {
 export interface SessionizerConfig {
   projects: {
     roots: string[];
+    git_only: boolean;
+    depth: number;
   };
   layout: {
     placement: PanePlacement;
@@ -116,6 +122,8 @@ export function loadConfig(): SessionizerConfig {
   if (roots.length === 0) {
     throw new Error("Config must define at least one [projects].roots entry.");
   }
+  const gitOnly = pluginConfig?.projects?.git_only ?? false;
+  const depth = asProjectDepth(pluginConfig?.projects?.depth);
 
   const focus = pluginConfig?.layout?.focus?.trim();
   if (!focus) {
@@ -125,6 +133,8 @@ export function loadConfig(): SessionizerConfig {
   return {
     projects: {
       roots,
+      git_only: gitOnly,
+      depth,
     },
     layout: {
       placement: asPlacement(pluginConfig?.layout?.placement),
@@ -197,6 +207,10 @@ function defaultConfigToml(): string {
     "[projects]",
     "# Parent folders searched by the interactive pickers",
     `roots = ["~/Projects", "~/Workspace"]`,
+    "# false: immediate child folders; true: recurse for Git repositories",
+    "git_only = false",
+    "# Only used when git_only = true; 1 means immediate children",
+    "depth = 1",
     "",
     "[layout]",
     "# How the plugin pane itself opens: overlay | split",
@@ -240,6 +254,23 @@ function asPlacement(value: string | undefined): PanePlacement {
   throw new Error(
     "Config must define [layout].placement as 'overlay' or 'split'."
   );
+}
+
+function asProjectDepth(value: unknown): number {
+  if (value === undefined) {
+    return 1;
+  }
+
+  if (
+    typeof value !== "number" ||
+    !Number.isInteger(value) ||
+    !Number.isFinite(value) ||
+    value < 1
+  ) {
+    throw new Error("Config [projects].depth must be an integer >= 1.");
+  }
+
+  return value;
 }
 
 function asSplitDirection(value: string | undefined): SplitDirection {

--- a/src/discovery/discovery.test.ts
+++ b/src/discovery/discovery.test.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, rmSync, rmdirSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  rmSync,
+  rmdirSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "bun:test";
@@ -201,6 +207,45 @@ describe("listProjects", () => {
     } finally {
       rmSync(join(extraRoot, "project-d"), { recursive: true, force: true });
       rmSync(extraRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("filters to immediate git repos when git_only is enabled with default depth", () => {
+    const repoRoot = join(sandbox, "repo-root");
+    const nestedRepo = join(sandbox, "group", "nested-repo");
+    mkdirSync(join(repoRoot, ".git"), { recursive: true });
+    mkdirSync(join(nestedRepo, ".git"), { recursive: true });
+
+    const projects = listProjects([sandbox], { git_only: true });
+
+    expect(projects).toEqual([repoRoot]);
+  });
+
+  it("uses depth when git_only is enabled", () => {
+    const nestedRepo = join(sandbox, "org", "team", "service");
+    mkdirSync(join(nestedRepo, ".git"), { recursive: true });
+
+    expect(listProjects([sandbox], { git_only: true, depth: 2 })).not.toContain(
+      nestedRepo
+    );
+    expect(listProjects([sandbox], { git_only: true, depth: 3 })).toContain(
+      nestedRepo
+    );
+  });
+
+  it("includes symlinked git repos when git_only is enabled", () => {
+    const external = join(tmpdir(), "herdr-sessionizer-external-repo");
+    const link = join(sandbox, "linked-repo");
+    rmSync(external, { recursive: true, force: true });
+    rmSync(link, { recursive: true, force: true });
+    mkdirSync(join(external, ".git"), { recursive: true });
+    symlinkSync(external, link, "dir");
+
+    try {
+      expect(listProjects([sandbox], { git_only: true })).toContain(link);
+    } finally {
+      rmSync(link, { recursive: true, force: true });
+      rmSync(external, { recursive: true, force: true });
     }
   });
 });

--- a/src/discovery/discovery.ts
+++ b/src/discovery/discovery.ts
@@ -1,20 +1,94 @@
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, realpathSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
+export interface ProjectDiscoveryOptions {
+  git_only?: boolean;
+  depth?: number;
+}
+
 /**
  * Enumerate project directories from a set of base root paths.
- * Scans each base for immediate child directories.
+ * Scans each base for immediate child directories by default.
  */
-export function listProjects(bases: readonly string[]): string[] {
+export function listProjects(
+  bases: readonly string[],
+  options: ProjectDiscoveryOptions = {}
+): string[] {
   const seen = new Set<string>();
+  const gitOnly = options.git_only ?? false;
+
   for (const base of bases) {
     if (!existsSync(base)) continue;
-    for (const entry of readdirSync(base, { withFileTypes: true })) {
-      if (entry.isDirectory()) seen.add(join(base, entry.name));
+
+    if (gitOnly) {
+      discoverGitProjects(base, options.depth ?? 1, seen);
+      continue;
+    }
+
+    for (const path of listChildDirectories(base)) {
+      seen.add(path);
     }
   }
+
   return [...seen].sort();
+}
+
+function discoverGitProjects(base: string, depth: number, seen: Set<string>) {
+  const visited = new Set<string>();
+
+  function visit(path: string, currentDepth: number) {
+    if (currentDepth > depth || !isDirectory(path)) return;
+
+    if (hasGitMetadata(path)) {
+      seen.add(path);
+      return;
+    }
+
+    const realPath = safeRealpath(path);
+    if (realPath) {
+      if (visited.has(realPath)) return;
+      visited.add(realPath);
+    }
+
+    for (const child of listChildDirectories(path)) {
+      visit(child, currentDepth + 1);
+    }
+  }
+
+  for (const child of listChildDirectories(base)) {
+    visit(child, 1);
+  }
+}
+
+function listChildDirectories(path: string): string[] {
+  try {
+    return readdirSync(path, { withFileTypes: true })
+      .map((entry) => join(path, entry.name))
+      .filter(isDirectory);
+  } catch {
+    return [];
+  }
+}
+
+function hasGitMetadata(path: string): boolean {
+  return existsSync(join(path, ".git"));
+}
+
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function safeRealpath(path: string): string | undefined {
+  try {
+    return realpathSync(path);
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/src/layouts/project.test.ts
+++ b/src/layouts/project.test.ts
@@ -10,7 +10,7 @@ import {
 
 function testConfig(overrides?: Partial<SessionizerConfig>): SessionizerConfig {
   return {
-    projects: { roots: ["/tmp"] },
+    projects: { roots: ["/tmp"], git_only: false, depth: 1 },
     layout: { placement: "overlay", focus: "assistant" },
     tabs: [
       {

--- a/src/sessionizer/sessionizer.test.ts
+++ b/src/sessionizer/sessionizer.test.ts
@@ -10,7 +10,7 @@ import { runSessionizer } from "./sessionizer.ts";
 
 function testConfig(): SessionizerConfig {
   return {
-    projects: { roots: ["/projects"] },
+    projects: { roots: ["/projects"], git_only: false, depth: 1 },
     layout: { placement: "overlay", focus: "assistant" },
     tabs: [],
   };

--- a/src/sessionizer/sessionizer.ts
+++ b/src/sessionizer/sessionizer.ts
@@ -1,6 +1,10 @@
 import { basename } from "node:path";
 
-import { listProjects, sanitizeName } from "../discovery/discovery.ts";
+import {
+  listProjects,
+  sanitizeName,
+  type ProjectDiscoveryOptions,
+} from "../discovery/discovery.ts";
 
 import type { Workspace } from "../client/types.ts";
 import { Herdr } from "../client/herdr.ts";
@@ -48,7 +52,7 @@ interface SessionizerRuntime {
   ) => Promise<string[] | null>;
   listProjects: (
     roots: string[],
-    options?: SessionizerConfig["projects"]
+    options?: ProjectDiscoveryOptions
   ) => string[];
   createLayout: LayoutApplier;
   logger: Pick<typeof console, "log" | "error">;

--- a/src/sessionizer/sessionizer.ts
+++ b/src/sessionizer/sessionizer.ts
@@ -46,7 +46,10 @@ interface SessionizerRuntime {
     rows: readonly string[],
     options?: PickOptions
   ) => Promise<string[] | null>;
-  listProjects: (roots: string[]) => string[];
+  listProjects: (
+    roots: string[],
+    options?: SessionizerConfig["projects"]
+  ) => string[];
   createLayout: LayoutApplier;
   logger: Pick<typeof console, "log" | "error">;
   exit: (code: number) => never;
@@ -97,7 +100,7 @@ export async function runSessionizer(
     return;
   }
 
-  const projects = runtime.listProjects(config.projects.roots);
+  const projects = runtime.listProjects(config.projects.roots, config.projects);
   if (projects.length === 0) {
     runtime.logger.error("No projects found in configured directories.");
     runtime.exit(1);

--- a/src/worktree/flow.ts
+++ b/src/worktree/flow.ts
@@ -61,7 +61,10 @@ export interface WorktreeFlowRuntime {
   config: SessionizerConfig;
   resolver: Pick<WorktreeResolver, "resolveExisting">;
   createLayout: LayoutApplier;
-  listProjects: (roots: string[]) => string[];
+  listProjects: (
+    roots: string[],
+    options?: SessionizerConfig["projects"]
+  ) => string[];
   pickProject: PickRows;
   pickWorktreeCandidate: PickRows;
   promptBranch: () => Promise<string>;
@@ -157,7 +160,10 @@ async function resolveInteractiveIntent(
   runtime: WorktreeFlowRuntime,
   workspaces: readonly Workspace[]
 ): Promise<WorktreeIntent> {
-  const projects = runtime.listProjects(runtime.config.projects.roots);
+  const projects = runtime.listProjects(
+    runtime.config.projects.roots,
+    runtime.config.projects
+  );
   if (projects.length === 0) {
     runtime.logger.error("No projects found in configured directories.");
     runtime.exit(1);

--- a/src/worktree/worktree.test.ts
+++ b/src/worktree/worktree.test.ts
@@ -37,7 +37,7 @@ function testRuntime(
     tabs: {},
     panes: {},
     config: {
-      projects: { roots: ["/repo"] },
+      projects: { roots: ["/repo"], git_only: false, depth: 1 },
       layout: { placement: "overlay", focus: "terminal" },
       tabs: [],
     },
@@ -233,7 +233,7 @@ describe("runWorktree", () => {
       createdWorkspace,
       "/Users/mac/.herdr/worktrees/repo/feature-test-flow",
       {
-        projects: { roots: ["/repo"] },
+        projects: { roots: ["/repo"], git_only: false, depth: 1 },
         layout: { placement: "overlay", focus: "terminal" },
         tabs: [],
       },
@@ -398,7 +398,7 @@ describe("runWorktree", () => {
       workspace,
       "/worktrees/repo/feature-test-flow",
       {
-        projects: { roots: ["/repo"] },
+        projects: { roots: ["/repo"], git_only: false, depth: 1 },
         layout: { placement: "overlay", focus: "terminal" },
         tabs: [],
       },


### PR DESCRIPTION
## Summary
- Add `[projects].git_only` and `[projects].depth` config options so the pickers can recurse and filter to Git repositories instead of only listing immediate child folders
- `git_only` defaults to `false` (unchanged behavior: lists immediate child directories)
- When `git_only = true`, recursively scans up to `depth` levels below each root (default `1`) and returns only directories containing `.git` metadata, following symlinks safely with cycle detection
- Update `README.md` to document the new config fields
- Update tests across config, discovery, sessionizer, and worktree modules to cover the new options and defaults