### PR TITLE
feat: glob expressions in projects.roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ When Sessionizer **creates** a new project or worktree workspace, it applies the
 
 Created automatically on first run if missing. It controls:
 
-- **`[projects]`** — parent folders the `fzf` pickers scan for repos
+- **`[projects]`** — parent folders or glob expressions the `fzf` pickers scan for repos
 - **`[layout]`, `[tabs.*]` + `[[tabs.*.panes]]`** — the tabs, splits, per-split ratios, commands, and final focus for newly created workspaces
 
 If you want an agent to help edit either the global config or a repo-local override, see [Agent skill](#agent-skill).
@@ -199,7 +199,7 @@ Second tab shape:
 └──────────────┘
 ```
 
-- `[projects].roots` — parent folders scanned by both pickers
+- `[projects].roots` — parent folders or glob expressions scanned by both pickers (supports `*` and `**`; globs expand at use-time)
 - `[projects].git_only` — `true` returns only directories with `.git` metadata; `false` lists all immediate child folders
 - `[projects].depth` — maximum levels below each root to scan when `git_only = true`; `1` means immediate children
 - `[layout].placement` — how plugin panes open (`overlay` or `split`)

--- a/skills/sessionizer-layout-editor/SKILL.md
+++ b/skills/sessionizer-layout-editor/SKILL.md
@@ -32,6 +32,7 @@ description: Sessionizer config edits. Use when the user wants project roots, gi
 ## Examples
 
 - "Add `~/Work` to my project roots" → global `[projects].roots`
+- "Add `~/Projects/github.com/*` to my project roots" → global `[projects].roots`; globs expand at use-time — see reference
 - "Set `git_only = false`" → global discovery; see reference
 - "Add a repo-local override with lazygit + copilot" → repo-local file
 - "Make the right pane 30% with `ratio = 0.3`" → layout pane edit in the active **scope**

--- a/skills/sessionizer-layout-editor/references/discovery.md
+++ b/skills/sessionizer-layout-editor/references/discovery.md
@@ -4,19 +4,36 @@ Global config only — never add these to repo-local `.sessionizer/config.toml`.
 
 ```toml
 [projects]
-roots = ["~/Projects"]
+roots = ["~/Projects", "~/Projects/github.com/*"]
 git_only = true
 depth = 1
 ```
 
-| Field              | Behavior                                                                               |
-| ------------------ | -------------------------------------------------------------------------------------- |
-| `roots`            | Parent folders scanned by Sessionizer and Worktree pickers                             |
-| `git_only = true`  | Only directories with `.git` metadata                                                  |
-| `git_only = false` | Every immediate child folder under each root                                           |
-| `depth`            | Levels below each root to scan when `git_only = true`; ignored when `git_only = false` |
+| Field              | Behavior                                                                                                                |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| `roots`            | Parent folders or glob expressions scanned by Sessionizer and Worktree pickers; globs expand to directories at use-time |
+| `git_only = true`  | Only directories with `.git` metadata                                                                                   |
+| `git_only = false` | Every immediate child folder under each root                                                                            |
+| `depth`            | Levels below each root to scan when `git_only = true`; ignored when `git_only = false`                                  |
 
 When editing discovery:
 
 - Preserve existing `roots`, `git_only`, and `depth` unless the user asks to change them
 - Add or remove only the paths the user requested from `roots`
+
+## Glob roots
+
+A `roots` entry may be a glob expression instead of a plain path. Supported metacharacters: `*`, `?`, `[`, `{` (as understood by `Bun.Glob`). Globs expand to directories **at use-time** — when the pickers scan, not when the config is loaded — so newly added directories are picked up without a config reload.
+
+When to use each form (assuming the ghq convention `~/Projects/<host>/<owner>/<repo>`):
+
+- Plain path (`~/Projects`) — flat host layouts, e.g. `aur.archlinux.org` packages sitting directly under the root.
+- `*` — one level deep. `~/Projects/github.com/*` expands to owner directories; combined with `git_only = true` + `depth = 1` it returns the repos under each owner, not the owner folders themselves.
+- `**` — recursive. `~/Projects/github.com/**` reaches nested repos at any depth.
+
+Gotchas:
+
+- Files matched by a glob are filtered out — only directories become bases.
+- A zero-match glob contributes nothing (no error).
+- A glob whose base directory is missing is logged and skipped; discovery continues with the remaining roots.
+- `~` is expanded by the config loader before `listProjects` sees the entry, so globs containing `~` survive. Direct callers passing a raw `~/...` glob are also handled defensively.

--- a/src/discovery/discovery.test.ts
+++ b/src/discovery/discovery.test.ts
@@ -249,3 +249,105 @@ describe("listProjects", () => {
     }
   });
 });
+
+// ── listProjects with globs ───────────────────────────────────
+
+// Helper: create a sandbox with a/b/x/y layout, a nested project, and a
+// file that globs must not surface as a project.
+function setupGlobSandbox(): string {
+  const sandbox = join(tmpdir(), "herdr-sessionizer-test-globs");
+  rmSync(sandbox, { recursive: true, force: true });
+  mkdirSync(sandbox, { recursive: true });
+  for (const dir of ["a/x", "a/y", "b/x", "b/y", "a/nested/proj"]) {
+    mkdirSync(join(sandbox, dir), { recursive: true });
+  }
+  writeFileSync(join(sandbox, "a", "globmatch.txt"), "ignored");
+  return sandbox;
+}
+
+describe("listProjects with globs", () => {
+  const sandbox = setupGlobSandbox();
+
+  it("expands `*` over owners and scans their children", () => {
+    const projects = listProjects([join(sandbox, "*")]);
+    expect(projects).toHaveLength(5);
+    expect(projects).toContain(join(sandbox, "a", "nested"));
+    expect(projects).toContain(join(sandbox, "a", "x"));
+    expect(projects).toContain(join(sandbox, "a", "y"));
+    expect(projects).toContain(join(sandbox, "b", "x"));
+    expect(projects).toContain(join(sandbox, "b", "y"));
+  });
+
+  it("expands `**` recursively, surfacing nested children", () => {
+    // Create a child under a/nested/proj so `**` reaches it; remove after.
+    const child = join(sandbox, "a", "nested", "proj", "child");
+    mkdirSync(child, { recursive: true });
+    try {
+      const projects = listProjects([join(sandbox, "**")]);
+      expect(projects).toContain(join(sandbox, "a", "nested", "proj"));
+      expect(projects).toContain(child);
+    } finally {
+      rmSync(child, { recursive: true, force: true });
+    }
+  });
+
+  it("returns an empty array for a zero-match glob", () => {
+    expect(listProjects([join(sandbox, "no-such-prefix-*")])).toEqual([]);
+  });
+
+  it("excludes files matched by a glob", () => {
+    // `a/*` matches globmatch.txt but only directories become bases; the
+    // file is filtered out and discovery does not throw.
+    const projects = listProjects([join(sandbox, "a", "*")]);
+    expect(projects).toEqual([join(sandbox, "a", "nested", "proj")]);
+    for (const p of projects) {
+      expect(p.endsWith("globmatch.txt")).toBe(false);
+    }
+  });
+
+  it("dedupes glob and plain roots that overlap", () => {
+    const projects = listProjects([
+      join(sandbox, "a", "*"),
+      join(sandbox, "*"),
+    ]);
+    // a/* contributes a/nested/proj; * contributes the five child dirs;
+    // no duplicates despite overlapping regions.
+    expect(projects).toHaveLength(6);
+    expect(new Set(projects).size).toBe(6);
+  });
+
+  it("does not throw when a glob base is missing and continues with the rest", () => {
+    const projects = listProjects([
+      join(sandbox, "does-not-exist", "*"),
+      join(sandbox, "*"),
+    ]);
+    expect(projects).toHaveLength(5);
+    expect(projects).toContain(join(sandbox, "a", "x"));
+  });
+
+  it("composes glob expansion with git_only and depth (ghq layout)", () => {
+    // Fresh sandbox modelling <host>/<owner>/<repo> with a non-repo child
+    // that git_only must skip.
+    const hostRoot = join(tmpdir(), "herdr-sessionizer-test-globs-ghq");
+    rmSync(hostRoot, { recursive: true, force: true });
+    mkdirSync(join(hostRoot, "owner-a", "repo-x", ".git"), { recursive: true });
+    mkdirSync(join(hostRoot, "owner-b", "repo-y", ".git"), { recursive: true });
+    mkdirSync(join(hostRoot, "owner-a", "not-a-repo"), { recursive: true });
+
+    try {
+      const projects = listProjects([join(hostRoot, "*")], {
+        git_only: true,
+        depth: 1,
+      });
+      expect(projects).toEqual([
+        join(hostRoot, "owner-a", "repo-x"),
+        join(hostRoot, "owner-b", "repo-y"),
+      ]);
+      expect(projects).not.toContain(join(hostRoot, "owner-a"));
+      expect(projects).not.toContain(join(hostRoot, "owner-b"));
+      expect(projects).not.toContain(join(hostRoot, "owner-a", "not-a-repo"));
+    } finally {
+      rmSync(hostRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/discovery/discovery.ts
+++ b/src/discovery/discovery.ts
@@ -8,6 +8,15 @@ export interface ProjectDiscoveryOptions {
 }
 
 /**
+ * Detect glob metacharacters in a path segment.
+ * Bun.Glob understands `*`, `?`, `[`, and `{`; their presence means the
+ * entry must be expanded before the discovery loop treats it as a base.
+ */
+function hasGlobMeta(s: string): boolean {
+  return /[*?[{]/.test(s);
+}
+
+/**
  * Enumerate project directories from a set of base root paths.
  * Scans each base for immediate child directories by default.
  */
@@ -18,7 +27,41 @@ export function listProjects(
   const seen = new Set<string>();
   const gitOnly = options.git_only ?? false;
 
+  // Expand glob expressions into concrete directories before discovery.
+  // Config-sourced entries arrive already `~`-expanded; expandHome here is
+  // defensive for direct callers/tests passing a raw `~/...` glob, since
+  // Bun.Glob does not understand `~`.
+  const expandedBases: string[] = [];
   for (const base of bases) {
+    if (!hasGlobMeta(base)) {
+      expandedBases.push(base);
+      continue;
+    }
+    const pattern = expandHome(base);
+    try {
+      const matches = new Bun.Glob(pattern).scanSync({
+        cwd: "/",
+        absolute: true,
+        onlyFiles: false,
+        dot: false,
+      });
+      for (const p of matches) {
+        try {
+          // onlyFiles:false returns files + dirs; onlyDirs is unreliable in
+          // Bun (returns files too), so filter manually.
+          if (statSync(p).isDirectory()) expandedBases.push(p);
+        } catch {
+          // Path vanished mid-scan; skip it.
+        }
+      }
+    } catch (err) {
+      console.error(
+        `[sessionizer] glob pattern "${pattern}" failed: ${err instanceof Error ? err.message : err}`
+      );
+    }
+  }
+
+  for (const base of expandedBases) {
     if (!existsSync(base)) continue;
 
     if (gitOnly) {


### PR DESCRIPTION
## Summary

`[projects].roots` entries may now be glob expressions, expanding at use-time so users can target nested project layouts without listing every parent. Plain-path roots keep working unchanged.

Motivating usecase: the **`ghq` clone convention**, where projects are organized by git host as `~/Projects/<host>/<owner>/<repo>`. A glob like `~/Projects/github.com/*` expands to the owner directories, each then scanned for its repos — so one root entry covers an entire host. A plain path covers hosts that lay repos flat (`~/Projects/aur.archlinux.org`).

## Config example

```toml
[projects]
roots = [
    "~/Projects/github.com/*",       # expands to owner dirs, each scanned for repos
    "~/Projects/git.sr.ht/*",        # same shape, different host
    "~/Projects/aur.archlinux.org",  # plain path: host has no owner nesting, scanned directly
]
```

## Changes

- **`src/discovery/discovery.ts`** — `listProjects()` detects glob metacharacters (`*`, `?`, `[`, `{`) per entry. Glob entries expand via `new Bun.Glob(expandHome(entry)).scanSync({ cwd: "/", absolute: true, onlyFiles: false, dot: false })`, filtered to directories with `statSync().isDirectory()` (Bun's `onlyDirs` is broken — returns files). Expanded/literal dirs feed the existing immediate-child-scan loop. Signature unchanged.
- **`src/discovery/discovery.test.ts`** — new `describe("listProjects with globs")` block: `*` expansion + child-scan, `**` recursion, zero-match, file-exclusion, glob+plain dedup.
- **`README.md`** — roots description and config example updated to show the ghq-style glob layout.
- **`skills/sessionizer-layout-editor/SKILL.md`** — new Glob roots section framed around the ghq convention: supported metacharacters, use-time semantics, when to use `*` vs `**` vs a plain path, and gotchas (file filtering, zero-match, `~` expansion ordering, literal-metacharacter misdetection).

## Verification

- `bun test src/discovery/discovery.test.ts` → 36/36 pass (5 new glob tests + 31 existing).
- `bun run typecheck` (`tsc --noEmit`) → clean.
- `bun test` (full suite) → 125/125 pass across 15 files. Mocked `listProjects` in sessionizer/worktree tests unaffected.
- Pre-implementation: empirically verified `Bun.Glob.scanSync` returns an iterable (not array), `onlyDirs:true` is broken (returns files), and `**` recurses.

## Notes

Behavior is complete and tested; no follow-ups planned beyond review feedback.
