### PR TITLE
feat: declare linux platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Sessionizer is a [Herdr](https://herdr.dev/) plugin that uses fuzzy pickers to o
 - **Sessionizer** — focus an existing workspace or create a new project workspace
 - **Worktree** — create or reopen a Git worktree workspace
 
-> **Platform:** macOS only for now. Tested on macOS; Linux support is planned.
+> **Platform:** macOS and Linux.
 
 ## Inspiration
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -3,7 +3,7 @@ name = "Sessionizer"
 version = "0.6.0"
 min_herdr_version = "0.7.0"
 description = "Inspired by ThePrimeagen's tmux-sessionizer: fuzzy pickers to open projects and Git worktrees into Herdr workspaces."
-platforms = ["macos"]
+platforms = ["macos", "linux"]
 
 [[build]]
 command = ["bun", "install", "--frozen-lockfile"]

--- a/src/prerequisites/prerequisites.ts
+++ b/src/prerequisites/prerequisites.ts
@@ -16,7 +16,8 @@ export function fzfMissingMessage(): string {
   return [
     "fzf is required for Sessionizer picker flows but was not found on PATH.",
     "Install it, then retry:",
-    "  brew install fzf",
+    "  macOS: brew install fzf",
+    "  Linux: install fzf with your distro's package manager",
     "  Docs: https://github.com/junegunn/fzf#installation",
   ].join("\n");
 }


### PR DESCRIPTION
## Summary

Closes #6.

Adds `linux` to `platforms` in `herdr-plugin.toml`, updates the README platform note, and broadens the fzf install hint beyond Homebrew.

## Rationale

I grepped the source for platform-specific code (`process.platform`, darwin/macOS conditionals) and found none: discovery is `node:fs`, pickers spawn `fzf` from `PATH`, and everything else goes through the `herdr` CLI. CI already runs the full suite on `ubuntu-latest`, so every test has been passing on Linux all along.

## Testing

- `bun run typecheck` and `bun test` (133 pass)
- Plugin in use on macOS / herdr 0.7.4

### Linux smoke validation (herdr 0.7.5, Linux)

Validated on a real Linux herdr host against this PR branch:

- `herdr plugin link` — accepted `platforms = ["macos", "linux"]`
- `sessionizer.open` and `sessionizer.worktree-open` — both succeeded (`exit_code: 0`)
- Plugin panes `sessionizer` and `worktree` opened successfully
- `resolveFzfBin()` found fzf on PATH; project discovery listed real roots
- No Linux-specific runtime bugs found

Test matrix: Linux (local host) + herdr 0.7.5 + bun 1.3.14 + fzf 0.60.0.