### PR TITLE
fix(discovery): expand bare ~ root to the home directory

### DIFF
--- a/src/discovery/discovery.test.ts
+++ b/src/discovery/discovery.test.ts
@@ -93,6 +93,16 @@ describe("expandHome", () => {
     expect(result).toStartWith("/");
     expect(result).toEndWith("/foo");
   });
+
+  it("expands a bare ~ to the home directory", () => {
+    const result = expandHome("~");
+    expect(result).toStartWith("/");
+    expect(result).not.toInclude("~");
+  });
+
+  it("leaves ~user paths unchanged", () => {
+    expect(expandHome("~other/foo")).toBe("~other/foo");
+  });
 });
 
 // ── shellQuote ──────────────────────────────────────────────

--- a/src/discovery/discovery.ts
+++ b/src/discovery/discovery.ts
@@ -153,6 +153,7 @@ export function normalizePath(path: string | undefined): string {
  * Expand a leading `~` to the user's home directory.
  */
 export function expandHome(value: string): string {
+  if (value === "~") return homedir();
   return value.startsWith("~/") ? value.replace("~", homedir()) : value;
 }
 


### PR DESCRIPTION
## Summary

`roots = ["~"]` silently produced no projects: `expandHome` only rewrites the `~/` prefix, so a bare `~` fell through unchanged, failed `existsSync`, and was dropped from discovery with no diagnostic.

This came up with repos sitting directly under `$HOME` (a dotfiles repo being the classic case): the natural config is `roots = ["~"]`, and the current workaround (`"~/"`) is easy to miss.

## Change

`expandHome("~")` now returns `homedir()`. `~user` paths remain untouched (new test pins that).

## Testing

- `bun test` (135 pass, 2 new expandHome cases)
- Reproduced the original silent drop by running `loadConfig` + `listProjects` against a config with `roots = ["~", ...]`