### PR TITLE
fix(sessionizer): focus existing workspace instead of duplicating

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,6 +1,7 @@
 export interface Workspace {
   workspace_id: string;
   label?: string;
+  path?: string;
   cwd?: string;
   worktree?: WorktreeProvenance;
   tab_count?: number;

--- a/src/sessionizer/sessionizer.test.ts
+++ b/src/sessionizer/sessionizer.test.ts
@@ -131,6 +131,91 @@ describe("runSessionizer", () => {
     expect(focus).toHaveBeenCalledWith("ws-project");
   });
 
+  it("focuses instead of duplicating when the picked project already has a workspace", async () => {
+    const create = mock(async (_options: unknown) => testWorkspace());
+    const focus = mock(async () => {});
+    const log = mock(() => {});
+    const open = testWorkspace({
+      cwd: "/projects/fieldnotes",
+      workspace_id: "ws-open",
+    });
+
+    await runSessionizer({
+      workspaces: {
+        list: mock(async () => [open]),
+        create,
+        focus,
+      },
+      tabs: testTabs(),
+      panes: testPanes(),
+      config: testConfig(),
+      pickRows: mock(
+        async (_rows: readonly string[], options?: { prompt?: string }) => {
+          if (options?.prompt === "Switch session (Esc for new): ") {
+            return null;
+          }
+
+          return ["/projects/fieldnotes"];
+        }
+      ),
+      listProjects: mock(() => ["/projects/fieldnotes"]),
+      createLayout: mock(async (workspace: Workspace) => workspace),
+      logger: { log, error: mock(() => {}) },
+      exit: (code) => {
+        throw new Error(`unexpected exit ${code}`);
+      },
+    });
+
+    expect(create).not.toHaveBeenCalled();
+    expect(focus).toHaveBeenCalledWith("ws-open");
+    expect(log).toHaveBeenCalledWith(
+      "✓ focused existing workspace for '/projects/fieldnotes' (ws-open)"
+    );
+  });
+
+  it("still creates a workspace when only a worktree workspace matches the project path", async () => {
+    const workspace = testWorkspace({
+      cwd: "/projects/fieldnotes",
+      workspace_id: "ws-new",
+    });
+    const create = mock(async () => workspace);
+    const focus = mock(async () => {});
+    const worktreeMatch = testWorkspace({
+      cwd: "/projects/fieldnotes",
+      workspace_id: "ws-worktree",
+      worktree: { branch: "main" },
+    });
+
+    await runSessionizer({
+      workspaces: {
+        list: mock(async () => [worktreeMatch]),
+        create,
+        focus,
+      },
+      tabs: testTabs(),
+      panes: testPanes(),
+      config: testConfig(),
+      pickRows: mock(
+        async (_rows: readonly string[], options?: { prompt?: string }) => {
+          if (options?.prompt === "Switch session (Esc for new): ") {
+            return null;
+          }
+
+          return ["/projects/fieldnotes"];
+        }
+      ),
+      listProjects: mock(() => ["/projects/fieldnotes"]),
+      createLayout: mock(async (created: Workspace) => created),
+      logger: { log: mock(() => {}), error: mock(() => {}) },
+      exit: (code) => {
+        throw new Error(`unexpected exit ${code}`);
+      },
+    });
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(focus).toHaveBeenCalledWith("ws-new");
+  });
+
   it("exits with an error when no projects are found", async () => {
     const error = mock(() => {});
 

--- a/src/sessionizer/sessionizer.test.ts
+++ b/src/sessionizer/sessionizer.test.ts
@@ -136,7 +136,7 @@ describe("runSessionizer", () => {
     const focus = mock(async () => {});
     const log = mock(() => {});
     const open = testWorkspace({
-      cwd: "/projects/fieldnotes",
+      path: "/projects/fieldnotes",
       workspace_id: "ws-open",
     });
 
@@ -171,6 +171,44 @@ describe("runSessionizer", () => {
     expect(log).toHaveBeenCalledWith(
       "✓ focused existing workspace for '/projects/fieldnotes' (ws-open)"
     );
+  });
+
+  it("falls back to the legacy cwd field when matching existing workspaces", async () => {
+    const create = mock(async (_options: unknown) => testWorkspace());
+    const focus = mock(async () => {});
+    const open = testWorkspace({
+      cwd: "/projects/fieldnotes",
+      workspace_id: "ws-legacy",
+    });
+
+    await runSessionizer({
+      workspaces: {
+        list: mock(async () => [open]),
+        create,
+        focus,
+      },
+      tabs: testTabs(),
+      panes: testPanes(),
+      config: testConfig(),
+      pickRows: mock(
+        async (_rows: readonly string[], options?: { prompt?: string }) => {
+          if (options?.prompt === "Switch session (Esc for new): ") {
+            return null;
+          }
+
+          return ["/projects/fieldnotes"];
+        }
+      ),
+      listProjects: mock(() => ["/projects/fieldnotes"]),
+      createLayout: mock(async (workspace: Workspace) => workspace),
+      logger: { log: mock(() => {}), error: mock(() => {}) },
+      exit: (code) => {
+        throw new Error(`unexpected exit ${code}`);
+      },
+    });
+
+    expect(create).not.toHaveBeenCalled();
+    expect(focus).toHaveBeenCalledWith("ws-legacy");
   });
 
   it("still creates a workspace when only a worktree workspace matches the project path", async () => {

--- a/src/sessionizer/sessionizer.ts
+++ b/src/sessionizer/sessionizer.ts
@@ -2,6 +2,7 @@ import { basename } from "node:path";
 
 import {
   listProjects,
+  normalizePath,
   sanitizeName,
   type ProjectDiscoveryOptions,
 } from "../discovery/discovery.ts";
@@ -87,17 +88,15 @@ export async function runSessionizer(
 ): Promise<void> {
   const { workspaces, tabs, panes, config } = runtime;
 
-  const existing = await runtime.pickRows(
-    (await workspaces.list()).map(workspaceRow),
-    {
-      prompt: "Switch session (Esc for new): ",
-      header: "↑↓ navigate, Enter select, Esc → new project",
-      delimiter: WORKSPACE_ROW_DELIMITER,
-      withNth: "2",
-      preview: WORKSPACE_PREVIEW,
-      previewWindow: "right:50%",
-    }
-  );
+  const allWorkspaces = await workspaces.list();
+  const existing = await runtime.pickRows(allWorkspaces.map(workspaceRow), {
+    prompt: "Switch session (Esc for new): ",
+    header: "↑↓ navigate, Enter select, Esc → new project",
+    delimiter: WORKSPACE_ROW_DELIMITER,
+    withNth: "2",
+    preview: WORKSPACE_PREVIEW,
+    previewWindow: "right:50%",
+  });
 
   if (existing && existing.length > 0) {
     await workspaces.focus(extractWorkspaceId(existing[0]!));
@@ -120,6 +119,15 @@ export async function runSessionizer(
   if (!selected || selected.length === 0) return;
 
   const project = selected[0]!;
+  const openWorkspace = findProjectWorkspace(allWorkspaces, project);
+  if (openWorkspace) {
+    await workspaces.focus(openWorkspace.workspace_id);
+    runtime.logger.log(
+      `✓ focused existing workspace for '${project}' (${openWorkspace.workspace_id})`
+    );
+    return;
+  }
+
   const projectName = project.split("/").pop() ?? project;
   const label = sanitizeName(projectName);
   const workspace = await workspaces.create({
@@ -134,6 +142,17 @@ export async function runSessionizer(
 
   runtime.logger.log(
     `✓ workspace '${label}' created and focused (${workspace.workspace_id})`
+  );
+}
+
+function findProjectWorkspace(
+  workspaces: readonly Workspace[],
+  projectPath: string
+): Workspace | undefined {
+  const normalizedProject = normalizePath(projectPath);
+  return workspaces.find(
+    (workspace) =>
+      !workspace.worktree && normalizePath(workspace.cwd) === normalizedProject
   );
 }
 

--- a/src/sessionizer/sessionizer.ts
+++ b/src/sessionizer/sessionizer.ts
@@ -152,7 +152,8 @@ function findProjectWorkspace(
   const normalizedProject = normalizePath(projectPath);
   return workspaces.find(
     (workspace) =>
-      !workspace.worktree && normalizePath(workspace.cwd) === normalizedProject
+      !workspace.worktree &&
+      normalizePath(workspace.path ?? workspace.cwd) === normalizedProject
   );
 }
 
@@ -184,6 +185,7 @@ function workspaceSummary(workspace: Workspace): string {
 
 function workspacePath(workspace: Workspace): string | undefined {
   return (
+    workspace.path ??
     workspace.cwd ??
     workspace.worktree?.checkout_path ??
     workspace.worktree?.repo_root ??


### PR DESCRIPTION
## Summary

In the sessionizer flow, dismissing the workspace picker (Esc) and then selecting a project that already has an open workspace created a second workspace for the same cwd. The worktree flow already guards against this via `findRepoWorkspaceId`; this brings the project flow in line.

## Change

- Reuse the workspace list already fetched for the first picker (no extra `herdr workspace list` call)
- If a non-worktree workspace's cwd matches the picked project (paths compared via `normalizePath`), focus it and log, instead of `create` + layout
- Worktree workspaces are excluded from the match so a plain project workspace can still be created alongside a worktree checkout of the same repo, mirroring the worktree flow's semantics

Layout is intentionally not reapplied on focus, consistent with the existing "existing workspaces are only focused" behavior documented in the README.

## Testing

- `bun run typecheck` and `bun test` (135 pass; 2 new cases: focus-instead-of-create, and worktree-only match still creates)