### PR TITLE
fix(config): make [layout] and [tabs] sections optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ When Sessionizer **creates** a new project or worktree workspace, it applies the
 
 Created automatically on first run if missing.
 
+`[layout]` and `[tabs]` are optional. A config with only `[projects]` is
+valid: new workspaces then open with a plain shell and no layout is applied.
+When `[tabs]` sections exist, `[layout].placement` and `[layout].focus` are
+required.
+
 If you want an agent to help edit either the global config or a repo-local override, see [Agent skills](#agent-skills).
 
 ### Example layout

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -124,6 +124,77 @@ describe("loadConfig", () => {
 });
 
 describe("resolveLayoutConfig", () => {
+  it("loads a projects-only config without [layout] or [tabs] sections", () => {
+    withPluginConfigDir((dir) => {
+      writeFileSync(
+        join(dir, "config.toml"),
+        ["[projects]", 'roots = ["~/Projects"]', ""].join("\n"),
+        "utf-8"
+      );
+
+      const config = loadConfig();
+
+      expect(config.tabs).toEqual([]);
+      expect(config.layout.placement).toBe("overlay");
+      expect(config.layout.focus).toBe("");
+    });
+  });
+
+  it("still requires [layout].focus when [tabs] sections exist", () => {
+    withPluginConfigDir((dir) => {
+      writeFileSync(
+        join(dir, "config.toml"),
+        [
+          "[projects]",
+          'roots = ["~/Projects"]',
+          "",
+          "[layout]",
+          'placement = "overlay"',
+          "",
+          "[tabs.dev]",
+          'label = "dev"',
+          "",
+          "[[tabs.dev.panes]]",
+          'title = "nvim"',
+          'command = "nvim"',
+          "",
+        ].join("\n"),
+        "utf-8"
+      );
+
+      expect(() => loadConfig()).toThrow("Config must define [layout].focus.");
+    });
+  });
+
+  it("still requires [layout].placement when [tabs] sections exist", () => {
+    withPluginConfigDir((dir) => {
+      writeFileSync(
+        join(dir, "config.toml"),
+        [
+          "[projects]",
+          'roots = ["~/Projects"]',
+          "",
+          "[layout]",
+          'focus = "editor"',
+          "",
+          "[tabs.dev]",
+          'label = "dev"',
+          "",
+          "[[tabs.dev.panes]]",
+          'id = "editor"',
+          'title = "nvim"',
+          'command = "nvim"',
+          "",
+        ].join("\n"),
+        "utf-8"
+      );
+
+      expect(() => loadConfig()).toThrow(
+        "Config must define [layout].placement as 'overlay' or 'split'."
+      );
+    });
+  });
+
   it("uses repo-local focus and tabs when override exists", () => {
     const repoRoot = mkdtempSync(join(tmpdir(), "sessionizer-repo-"));
     const configPath = writeRepoLayout(

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -125,8 +125,9 @@ export function loadConfig(): SessionizerConfig {
   const gitOnly = pluginConfig?.projects?.git_only ?? false;
   const depth = asProjectDepth(pluginConfig?.projects?.depth);
 
+  const tabs = buildTabs(pluginConfig, { required: false });
   const focus = pluginConfig?.layout?.focus?.trim();
-  if (!focus) {
+  if (!focus && tabs.length > 0) {
     throw new Error("Config must define [layout].focus.");
   }
 
@@ -137,10 +138,12 @@ export function loadConfig(): SessionizerConfig {
       depth,
     },
     layout: {
-      placement: asPlacement(pluginConfig?.layout?.placement),
-      focus,
+      placement: asPlacement(pluginConfig?.layout?.placement, {
+        required: tabs.length > 0,
+      }),
+      focus: focus ?? "",
     },
-    tabs: buildTabs(pluginConfig),
+    tabs,
   };
 }
 
@@ -156,9 +159,15 @@ function loadRaw(path: string): RawConfig | undefined {
   return parse(readFileSync(path, "utf-8")) as RawConfig;
 }
 
-function buildTabs(config: RawConfig | undefined): TabConfig[] {
+function buildTabs(
+  config: RawConfig | undefined,
+  options: { required: boolean } = { required: true }
+): TabConfig[] {
   const rawTabs = config?.tabs;
   if (!rawTabs || Object.keys(rawTabs).length === 0) {
+    if (!options.required) {
+      return [];
+    }
     throw new Error("Config must define at least one [tabs.<name>] section.");
   }
 
@@ -249,8 +258,12 @@ function defaultConfigToml(): string {
   ].join("\n");
 }
 
-function asPlacement(value: string | undefined): PanePlacement {
+function asPlacement(
+  value: string | undefined,
+  options: { required: boolean } = { required: true }
+): PanePlacement {
   if (value === "overlay" || value === "split") return value;
+  if (value === undefined && !options.required) return "overlay";
   throw new Error(
     "Config must define [layout].placement as 'overlay' or 'split'."
   );


### PR DESCRIPTION
## Summary

A config containing only `[projects]` currently throws at load time (`Config must define [layout].focus.` / `...at least one [tabs.<name>] section.`), which crashes both pickers for users who just want project switching without layout bootstrapping.

## Change

- Empty or missing `[tabs]` now yields `tabs: []`, and `createProjectLayout` already treats that as a no-op, so new workspaces open with a plain shell
- `[layout].placement` defaults to `overlay` and `[layout].focus` to empty only when there are no tabs; when `[tabs]` sections exist both remain required with the same error messages
- Repo-local `.sessionizer/config.toml` overrides keep their strict validation unchanged
- README documents the minimal-config behavior

## Testing

- `bun run typecheck`, `bun test` (136 pass; 3 new cases: projects-only config loads with defaults, focus still required with tabs, placement still required with tabs)