### PR TITLE
fix(worktree): gate branch fallback on git state, not stderr text

### DIFF
--- a/src/worktree/branch-fallback.test.ts
+++ b/src/worktree/branch-fallback.test.ts
@@ -3,7 +3,10 @@ import { join } from "node:path";
 
 import { describe, expect, it, mock } from "bun:test";
 
-import { attachExistingBranchWorktree } from "./branch-fallback.ts";
+import {
+  attachExistingBranchWorktree,
+  localBranchExists,
+} from "./branch-fallback.ts";
 
 const worktreePath = join(
   homedir(),
@@ -106,5 +109,41 @@ describe("attachExistingBranchWorktree", () => {
     ).rejects.toThrow(
       `target worktree path '${worktreePath}' already exists but is not a reusable checkout for branch 'feature/test-flow'; remove or relocate that directory and retry`
     );
+  });
+});
+
+describe("localBranchExists", () => {
+  it("returns true when git verifies the branch ref", async () => {
+    const runGit = mock(async (_cwd: string, args: string[]) => {
+      expect(args).toEqual([
+        "rev-parse",
+        "--verify",
+        "--quiet",
+        "refs/heads/feature/test-flow",
+      ]);
+      return { stdout: "abc123\n", stderr: "", exitCode: 0 };
+    });
+
+    await expect(
+      localBranchExists("/repo", "feature/test-flow", {
+        runGit,
+        pathExists: () => true,
+      })
+    ).resolves.toBe(true);
+  });
+
+  it("returns false when the branch ref is missing", async () => {
+    const runGit = mock(async () => ({
+      stdout: "",
+      stderr: "",
+      exitCode: 1,
+    }));
+
+    await expect(
+      localBranchExists("/repo", "missing", {
+        runGit,
+        pathExists: () => true,
+      })
+    ).resolves.toBe(false);
   });
 });

--- a/src/worktree/branch-fallback.ts
+++ b/src/worktree/branch-fallback.ts
@@ -38,6 +38,20 @@ const defaultRuntime: WorktreeBranchFallbackRuntime = {
   pathExists: existsSync,
 };
 
+export async function localBranchExists(
+  project: string,
+  branch: string,
+  runtime: WorktreeBranchFallbackRuntime = defaultRuntime
+): Promise<boolean> {
+  const result = await runtime.runGit(project, [
+    "rev-parse",
+    "--verify",
+    "--quiet",
+    `refs/heads/${branch}`,
+  ]);
+  return result.exitCode === 0;
+}
+
 export async function attachExistingBranchWorktree(
   project: string,
   branch: string,

--- a/src/worktree/flow.ts
+++ b/src/worktree/flow.ts
@@ -72,6 +72,7 @@ export interface WorktreeFlowRuntime {
     options: DiscoverWorktreeCandidateOptions
   ) => Promise<WorktreeCandidate[]>;
   attachExistingBranch: (project: string, branch: string) => Promise<string>;
+  localBranchExists: (project: string, branch: string) => Promise<boolean>;
   logger: Pick<typeof console, "log" | "error">;
   exit: (code: number) => never;
 }
@@ -296,10 +297,12 @@ async function openOrCreateWorktree(
   } catch (error) {
     const herdrError = asHerdrError(error);
     if (!herdrError) throw error;
+    const branchExists = await runtime.localBranchExists(project, branch);
     const existing = await runtime.resolver.resolveExisting({
       project,
       branch,
       error: herdrError,
+      branchExists,
     });
     if (existing) {
       await runtime.worktrees.open({
@@ -313,7 +316,7 @@ async function openOrCreateWorktree(
       );
       return;
     }
-    if (!isDuplicateBranchError(herdrError)) throw herdrError;
+    if (!branchExists) throw herdrError;
 
     const path = await runtime.attachExistingBranch(project, branch);
     const reopened = await runtime.worktrees.open({
@@ -446,10 +449,6 @@ function asHerdrError(error: unknown): HerdrError | undefined {
     return error as HerdrError;
   }
   return undefined;
-}
-
-function isDuplicateBranchError(error: HerdrError): boolean {
-  return error.stderr.includes("a branch named");
 }
 
 export const defaultDiscoverWorktreeCandidates = discoverWorktreeCandidates;

--- a/src/worktree/resolver.test.ts
+++ b/src/worktree/resolver.test.ts
@@ -130,6 +130,7 @@ describe("WorktreeResolver", () => {
         project: "/repo",
         branch: "feature/test-flow",
         error,
+        branchExists: true,
       })
     ).resolves.toEqual({
       path: "/repo/feature-test-flow",
@@ -160,6 +161,7 @@ describe("WorktreeResolver", () => {
         project: "/repo",
         branch: "feature/test flow",
         error,
+        branchExists: true,
       })
     ).resolves.toEqual({
       path: "/repo/feature-test-flow",

--- a/src/worktree/resolver.ts
+++ b/src/worktree/resolver.ts
@@ -12,6 +12,8 @@ export interface ResolveExistingWorktreeOptions {
   project: string;
   branch: string;
   error?: HerdrError;
+  /** Whether the local branch already exists, checked against git state. */
+  branchExists?: boolean;
 }
 
 export type ListWorktreesPorcelain = (
@@ -31,7 +33,7 @@ export class WorktreeResolver {
       return { path: errorPath, source: "error" };
     }
 
-    if (!shouldInspectGit(options.error)) {
+    if (!shouldInspectGit(options)) {
       return undefined;
     }
 
@@ -111,8 +113,8 @@ export function existingWorktreePathFromPorcelainBySlug(
   return undefined;
 }
 
-function shouldInspectGit(error: HerdrError | undefined): boolean {
-  return !error || error.stderr.includes("a branch named");
+function shouldInspectGit(options: ResolveExistingWorktreeOptions): boolean {
+  return !options.error || options.branchExists === true;
 }
 
 async function defaultListWorktreesPorcelain(

--- a/src/worktree/worktree.test.ts
+++ b/src/worktree/worktree.test.ts
@@ -49,6 +49,7 @@ function testRuntime(
     promptBranch: mock(async () => "feature/test-flow"),
     discoverCandidates: mock(async () => []),
     attachExistingBranch: mock(async () => "/repo/feature-test-flow"),
+    localBranchExists: mock(async () => true),
     logger: { log: mock(() => {}), error: mock(() => {}) },
     exit: (code) => {
       throw new Error(`unexpected exit ${code}`);
@@ -141,6 +142,7 @@ describe("runWorktree", () => {
       project: "/repo",
       branch: "feature/test-flow",
       error: duplicateBranchError,
+      branchExists: true,
     });
     expect(open.mock.calls[1]?.[0]).toEqual({
       workspaceId: undefined,
@@ -154,6 +156,34 @@ describe("runWorktree", () => {
     expect(log).toHaveBeenCalledWith(
       "✓ opened existing worktree path '/repo/feature-test-flow' for 'feature/test-flow'"
     );
+  });
+
+  it("rethrows the create error when the local branch does not exist", async () => {
+    const unrelatedError = new HerdrError(
+      ["worktree", "create"],
+      1,
+      "fatal: could not create work tree dir: Permission denied"
+    );
+    const open = mock(async () => {
+      throw unrelatedError;
+    });
+    const create = mock(async () => {
+      throw unrelatedError;
+    });
+    const attachExistingBranch = mock(async () => "/unused");
+    const runtime = testRuntime({
+      worktrees: { open, create },
+      localBranchExists: mock(async () => false),
+      attachExistingBranch,
+    });
+
+    await expect(
+      runWorktree(
+        ["--project", "/repo", "--branch", "feature/test-flow"],
+        runtime
+      )
+    ).rejects.toBe(unrelatedError);
+    expect(attachExistingBranch).not.toHaveBeenCalled();
   });
 
   it("attaches an existing branch as a new worktree when no existing checkout can be resolved", async () => {

--- a/src/worktree/worktree.ts
+++ b/src/worktree/worktree.ts
@@ -9,7 +9,10 @@ import { Workspaces } from "../ops/workspaces.ts";
 import { Worktrees } from "../ops/worktrees.ts";
 import { pick } from "../ui/fzf.ts";
 import { promptText } from "../ui/prompt.ts";
-import { attachExistingBranchWorktree } from "./branch-fallback.ts";
+import {
+  attachExistingBranchWorktree,
+  localBranchExists,
+} from "./branch-fallback.ts";
 import {
   defaultDiscoverWorktreeCandidates,
   runWorktreeFlow,
@@ -64,6 +67,7 @@ function createRuntime(): WorktreeFlowRuntime {
     promptBranch: promptBranchName,
     discoverCandidates: defaultDiscoverWorktreeCandidates,
     attachExistingBranch: attachExistingBranchWorktree,
+    localBranchExists,
     logger: console,
     exit: (code) => process.exit(code),
   };


### PR DESCRIPTION
## Summary

The duplicate-branch fallback decides whether to attach an existing branch by matching herdr's stderr against the literal string `a branch named` (in `flow.ts` and `resolver.ts`'s `shouldInspectGit`). Any wording change in herdr's git error passthrough would silently disable the fallback and surface raw create errors instead.

## Change

- New `localBranchExists(project, branch)` in `branch-fallback.ts`: `git rev-parse --verify --quiet refs/heads/<branch>`
- `flow.ts` checks it once on create failure, threads it to the resolver as `branchExists`, and gates `attachExistingBranch` on it; `isDuplicateBranchError` is gone
- `resolver.ts` inspects git porcelain when there is no error or when the branch is known to exist, instead of sniffing the message
- Behavior tightens in one way: an unrelated create failure (e.g. permissions) with no such local branch now rethrows instead of depending on message wording

## Testing

- `bun run typecheck`, `bun test` (136 pass; new cases: rethrow when branch missing, localBranchExists true/false)
- Sanity-checked `localBranchExists` against a real repo (existing and missing branch)