### PR TITLE
chore(release): prepare 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.6.1] - 2026-07-21
+
+### Fixed
+
+- Expand a bare `~` project root to the home directory (was silently ignored)
+
+### Changed
+
+- Dev dependency: TypeScript 7.0 (typecheck only; no runtime change)
+- README cleanup for UX flow, config field reference, and glob roots guidance
+
+Thanks @pperanich ([#26](https://github.com/andrewchng/herdr-sessionizer/pull/26)).
+
 ## [0.6.0] - 2026-07-08
 
 ### Added

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "sessionizer"
 name = "Sessionizer"
-version = "0.6.0"
+version = "0.6.1"
 min_herdr_version = "0.7.0"
 description = "Inspired by ThePrimeagen's tmux-sessionizer: fuzzy pickers to open projects and Git worktrees into Herdr workspaces."
 platforms = ["macos"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "herdr-plugin-sessionizer",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "description": "Herdr plugin inspired by ThePrimeagen's tmux-sessionizer for fuzzy project and worktree picking",


### PR DESCRIPTION
## Summary
- Bump version to 0.6.1 in `package.json` and `herdr-plugin.toml`
- Changelog: bare `~` root fix (#26), TypeScript 7, README cleanup; credit @pperanich

## Test plan
- [x] `bun test` (135 pass)
- [x] `bun run typecheck`