### PR TITLE
feat(worktree): apply the layout when opening an existing worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Generated default `config.toml` now seeds `[ui].placement = "overlay"` (previously `popup` at 90%); switch to `popup` explicitly for the session-modal picker
+- Opening an existing worktree checkout now applies the tab layout (same as create). Focusing an existing Herdr workspace is unchanged.
 
 ## [0.7.1] - 2026-08-01
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ description = "open worktree workspace"
 
 ## Layout configuration
 
-When Sessionizer **creates** a new project or worktree workspace, it applies the layout from `config.toml`. Existing workspaces are only focused — the layout is not reapplied.
+When Sessionizer **creates** a new project or worktree workspace, or **opens** an existing worktree checkout, it applies the layout from `config.toml`. Focusing an existing Herdr workspace is unchanged — the layout is not reapplied.
 
 ```text
 ~/.config/herdr/plugins/config/sessionizer/config.toml
@@ -280,7 +280,8 @@ When Sessionizer or Worktree creates a new workspace at `cwd`, Sessionizer check
 | ------------------------------------------- | ---------------------------------------------------- |
 | Sessionizer creates a new project workspace | Repo override at picked `cwd`, else global default   |
 | Worktree creates a new workspace            | Repo override at checkout `cwd`, else global default |
-| Focus or reopen an existing workspace       | No relayout                                          |
+| Worktree opens an existing checkout         | Repo override at checkout `cwd`, else global default |
+| Focus an existing workspace                 | No relayout                                          |
 
 #### Example repo override
 

--- a/skills/sessionizer-layout-editor/SKILL.md
+++ b/skills/sessionizer-layout-editor/SKILL.md
@@ -12,7 +12,7 @@ description: Sessionizer config edits. Use when the user wants project roots, gi
 | global     | `~/.config/herdr/plugins/config/sessionizer/config.toml` |
 | repo-local | `<repo>/.sessionizer/config.toml`                        |
 
-**Bootstrap** — layout changes (`[layout].focus`, `[tabs.*]`) apply only when Sessionizer or Worktree creates a **new** workspace, not on reopen. **Picker UI** (`[ui]`) applies every time a picker opens and is global-only.
+**Bootstrap** — layout changes (`[layout].focus`, `[tabs.*]`) apply when Sessionizer or Worktree creates a **new** workspace, or when it opens an existing worktree checkout (not when an existing Herdr workspace is only focused). **Picker UI** (`[ui]`) applies every time a picker opens and is global-only.
 
 ## Workflow
 

--- a/src/ops/worktrees.test.ts
+++ b/src/ops/worktrees.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, mock } from "bun:test";
+
+import type { Herdr } from "../client/herdr.ts";
+import type { Workspace } from "../client/types.ts";
+import { Worktrees } from "./worktrees.ts";
+
+function workspace(): Workspace {
+  return {
+    workspace_id: "ws-feature",
+    cwd: "/worktrees/repo/feature-test-flow",
+    tab_count: 1,
+    pane_count: 1,
+    worktree: {
+      checkout_path: "/worktrees/repo/feature-test-flow",
+    },
+  };
+}
+
+function herdrWithResult(result: Record<string, unknown>): Herdr {
+  return {
+    json: mock(async (_args: readonly string[]) => ({ result })),
+  } as unknown as Herdr;
+}
+
+describe("Worktrees.open", () => {
+  it("maps already_open false to alreadyOpen false for a fresh open", async () => {
+    const herdr = herdrWithResult({
+      workspace: workspace(),
+      already_open: false,
+      worktree: { checkout_path: "/worktrees/repo/feature-test-flow" },
+    });
+
+    const opened = await new Worktrees(herdr).open({
+      cwd: "/repo",
+      branch: "feature/test-flow",
+      focus: true,
+    });
+
+    expect(opened.alreadyOpen).toBe(false);
+    expect(opened.workspace?.workspace_id).toBe("ws-feature");
+    expect(opened.worktreePath).toBe("/worktrees/repo/feature-test-flow");
+  });
+
+  it("maps already_open true to alreadyOpen true when herdr refocuses an open workspace", async () => {
+    const herdr = herdrWithResult({
+      workspace: workspace(),
+      already_open: true,
+    });
+
+    const opened = await new Worktrees(herdr).open({
+      cwd: "/repo",
+      branch: "feature/test-flow",
+      focus: true,
+    });
+
+    expect(opened.alreadyOpen).toBe(true);
+    expect(opened.workspace?.workspace_id).toBe("ws-feature");
+  });
+});

--- a/src/ops/worktrees.ts
+++ b/src/ops/worktrees.ts
@@ -1,5 +1,5 @@
-import type { Herdr } from '../client/herdr.ts';
-import type { Workspace } from '../client/types.ts';
+import type { Herdr } from "../client/herdr.ts";
+import type { Workspace } from "../client/types.ts";
 
 export interface WorktreeCreateOptions {
   workspaceId?: string;
@@ -23,6 +23,7 @@ export interface WorktreeOpenOptions {
 interface WorktreeEnvelope {
   result?: {
     workspace?: Workspace;
+    already_open?: boolean;
     worktree?: {
       path?: string;
       checkout_path?: string;
@@ -33,50 +34,57 @@ interface WorktreeEnvelope {
 export interface WorktreeOpenResult {
   workspace?: Workspace;
   worktreePath?: string;
+  /** True when herdr refocused an already-open workspace instead of opening the checkout fresh. */
+  alreadyOpen: boolean;
 }
 
 export class Worktrees {
   constructor(private readonly herdr: Herdr) {}
 
   async create(options: WorktreeCreateOptions): Promise<Workspace> {
-    const args = ['worktree', 'create'];
-    if (options.workspaceId) args.push('--workspace', options.workspaceId);
-    else if (options.cwd) args.push('--cwd', options.cwd);
-    else throw new Error('worktree create requires either workspaceId or cwd');
+    const args = ["worktree", "create"];
+    if (options.workspaceId) args.push("--workspace", options.workspaceId);
+    else if (options.cwd) args.push("--cwd", options.cwd);
+    else throw new Error("worktree create requires either workspaceId or cwd");
 
-    args.push('--branch', options.branch, '--label', options.label, '--json');
-    if (options.base) args.push('--base', options.base);
-    if (options.path) args.push('--path', options.path);
-    if (options.focus === false) args.push('--no-focus');
-    else if (options.focus === true) args.push('--focus');
+    args.push("--branch", options.branch, "--label", options.label, "--json");
+    if (options.base) args.push("--base", options.base);
+    if (options.path) args.push("--path", options.path);
+    if (options.focus === false) args.push("--no-focus");
+    else if (options.focus === true) args.push("--focus");
 
     const response = await this.herdr.json<WorktreeEnvelope>(args);
     const workspace = response.result?.workspace;
     if (!workspace) {
-      throw new Error('worktree create succeeded but no workspace was returned');
+      throw new Error(
+        "worktree create succeeded but no workspace was returned"
+      );
     }
     return workspace;
   }
 
   async open(options: WorktreeOpenOptions): Promise<WorktreeOpenResult> {
-    const args = ['worktree', 'open'];
-    if (options.workspaceId) args.push('--workspace', options.workspaceId);
-    else if (options.cwd) args.push('--cwd', options.cwd);
-    else throw new Error('worktree open requires either workspaceId or cwd');
+    const args = ["worktree", "open"];
+    if (options.workspaceId) args.push("--workspace", options.workspaceId);
+    else if (options.cwd) args.push("--cwd", options.cwd);
+    else throw new Error("worktree open requires either workspaceId or cwd");
 
-    if (options.path) args.push('--path', options.path);
-    else if (options.branch) args.push('--branch', options.branch);
-    else throw new Error('worktree open requires either branch or path');
+    if (options.path) args.push("--path", options.path);
+    else if (options.branch) args.push("--branch", options.branch);
+    else throw new Error("worktree open requires either branch or path");
 
-    args.push('--json');
-    if (options.label) args.push('--label', options.label);
-    if (options.focus === false) args.push('--no-focus');
-    else if (options.focus === true) args.push('--focus');
+    args.push("--json");
+    if (options.label) args.push("--label", options.label);
+    if (options.focus === false) args.push("--no-focus");
+    else if (options.focus === true) args.push("--focus");
 
     const response = await this.herdr.json<WorktreeEnvelope>(args);
     return {
       workspace: response.result?.workspace,
-      worktreePath: response.result?.worktree?.checkout_path ?? response.result?.worktree?.path,
+      worktreePath:
+        response.result?.worktree?.checkout_path ??
+        response.result?.worktree?.path,
+      alreadyOpen: response.result?.already_open ?? false,
     };
   }
 }

--- a/src/worktree/flow.ts
+++ b/src/worktree/flow.ts
@@ -7,7 +7,7 @@ import { resolveLayoutConfig } from "../config/config.ts";
 import type { PickOptions } from "../ui/fzf.ts";
 import { PROJECT_PREVIEW, WORKTREE_CANDIDATE_PREVIEW } from "../ui/previews.ts";
 import type { WorktreeResolver } from "./resolver.ts";
-import type { Worktrees } from "../ops/worktrees.ts";
+import type { Worktrees, WorktreeOpenResult } from "../ops/worktrees.ts";
 import type {
   DiscoverWorktreeCandidateOptions,
   WorktreeCandidate,
@@ -137,15 +137,17 @@ export async function runWorktreeFlow(
   const repoWorkspaceId = findRepoWorkspaceId(workspaces, intent.project);
 
   if (intent.kind === "open-worktree") {
-    await runtime.worktrees.open({
+    const opened = await runtime.worktrees.open({
       workspaceId: repoWorkspaceId,
       cwd: repoWorkspaceId ? undefined : intent.project,
       path: intent.path,
       focus: true,
     });
-    runtime.logger.log(
-      `✓ opened existing worktree path '${intent.path}' for '${intent.branch}'`
-    );
+    await bootstrapOpenedWorktree(runtime, opened, {
+      branch: intent.branch,
+      fallbackPath: intent.path,
+      openedMessage: `✓ opened existing worktree path '${intent.path}' for '${intent.branch}'`,
+    });
     return;
   }
 
@@ -275,13 +277,18 @@ async function openOrCreateWorktree(
   }
 
   try {
-    await runtime.worktrees.open({
+    const opened = await runtime.worktrees.open({
       workspaceId: repoWorkspaceId,
       cwd: repoWorkspaceId ? undefined : project,
       branch,
       focus: true,
     });
-    runtime.logger.log(`✓ opened existing worktree '${branch}'`);
+    await bootstrapOpenedWorktree(runtime, opened, {
+      branch,
+      command,
+      fallbackPath: project,
+      openedMessage: `✓ opened existing worktree '${branch}'`,
+    });
     return;
   } catch (error) {
     if (!asHerdrError(error)) throw error;
@@ -309,15 +316,18 @@ async function openOrCreateWorktree(
       branchExists,
     });
     if (existing) {
-      await runtime.worktrees.open({
+      const opened = await runtime.worktrees.open({
         workspaceId: repoWorkspaceId,
         cwd: repoWorkspaceId ? undefined : project,
         path: existing.path,
         focus: true,
       });
-      runtime.logger.log(
-        `✓ opened existing worktree path '${existing.path}' for '${branch}'`
-      );
+      await bootstrapOpenedWorktree(runtime, opened, {
+        branch,
+        command,
+        fallbackPath: existing.path,
+        openedMessage: `✓ opened existing worktree path '${existing.path}' for '${branch}'`,
+      });
       return;
     }
     if (!branchExists) throw herdrError;
@@ -359,6 +369,7 @@ async function bootstrapWorktree(
     layoutFallback: string;
     branch: string;
     command?: string;
+    verb?: "created" | "opened";
   }
 ): Promise<void> {
   const layoutCwd = await resolveLayoutCwd(
@@ -379,9 +390,32 @@ async function bootstrapWorktree(
     }
   );
   await runtime.workspaces.focus(workspace.workspace_id);
+  const verb = options.verb ?? "created";
   runtime.logger.log(
-    `✓ worktree '${options.branch}' created and focused (${workspace.workspace_id})`
+    `✓ worktree '${options.branch}' ${verb} and focused (${workspace.workspace_id})`
   );
+}
+
+async function bootstrapOpenedWorktree(
+  runtime: WorktreeFlowRuntime,
+  opened: WorktreeOpenResult,
+  options: {
+    branch: string;
+    command?: string;
+    fallbackPath: string;
+    openedMessage: string;
+  }
+): Promise<void> {
+  if (opened.workspace) {
+    await bootstrapWorktree(runtime, opened.workspace, {
+      layoutFallback: opened.worktreePath ?? options.fallbackPath,
+      branch: options.branch,
+      command: options.command,
+      verb: "opened",
+    });
+    return;
+  }
+  runtime.logger.log(options.openedMessage);
 }
 
 export function parseArgs(argv: readonly string[]): CliArgs {

--- a/src/worktree/flow.ts
+++ b/src/worktree/flow.ts
@@ -340,17 +340,12 @@ async function openOrCreateWorktree(
       label,
       focus: false,
     });
-    const reopenedWorkspace = reopened.workspace;
-    if (!reopenedWorkspace) {
-      throw new Error(
-        `worktree open succeeded but no workspace was returned for '${path}'`
-      );
-    }
-
-    await bootstrapWorktree(runtime, reopenedWorkspace, {
-      layoutFallback: reopened.worktreePath ?? path,
+    await bootstrapOpenedWorktree(runtime, reopened, {
       branch,
       command,
+      fallbackPath: path,
+      openedMessage: `✓ attached existing branch '${branch}' at '${path}'`,
+      verb: "created",
     });
     return;
   }
@@ -404,16 +399,22 @@ async function bootstrapOpenedWorktree(
     command?: string;
     fallbackPath: string;
     openedMessage: string;
+    verb?: "created" | "opened";
   }
 ): Promise<void> {
-  if (opened.workspace) {
+  if (opened.workspace && !opened.alreadyOpen) {
     await bootstrapWorktree(runtime, opened.workspace, {
       layoutFallback: opened.worktreePath ?? options.fallbackPath,
       branch: options.branch,
       command: options.command,
-      verb: "opened",
+      verb: options.verb ?? "opened",
     });
     return;
+  }
+  // Reattach of an already-open workspace: focus only, never relayout
+  // (ADR-0001). Idempotent where `worktree open --focus` already focused.
+  if (opened.workspace) {
+    await runtime.workspaces.focus(opened.workspace.workspace_id);
   }
   runtime.logger.log(options.openedMessage);
 }

--- a/src/worktree/worktree.test.ts
+++ b/src/worktree/worktree.test.ts
@@ -26,7 +26,7 @@ function testRuntime(
 ): WorktreeFlowRuntime {
   return {
     worktrees: {
-      open: mock(async () => ({})),
+      open: mock(async () => ({ alreadyOpen: false })),
       create: mock(async () => testWorkspace()),
     },
     workspaces: {
@@ -86,6 +86,7 @@ describe("runWorktree", () => {
         return {
           workspace: existingWorkspace,
           worktreePath: "/repo/feature-test-flow",
+          alreadyOpen: false,
         };
       }
     );
@@ -229,6 +230,7 @@ describe("runWorktree", () => {
         return {
           workspace: createdWorkspace,
           worktreePath: "/Users/mac/.herdr/worktrees/repo/feature-test-flow",
+          alreadyOpen: false,
         };
       }
     );
@@ -673,6 +675,7 @@ describe("runWorktree", () => {
     const open = mock(async () => ({
       workspace: openedWorkspace,
       worktreePath: "/worktrees/repo/feature-test-flow",
+      alreadyOpen: false,
     }));
     const createLayout = mock(async (workspace: Workspace) => workspace);
     const focus = mock(async () => {});
@@ -734,6 +737,7 @@ describe("runWorktree", () => {
     const open = mock(async () => ({
       workspace: openedWorkspace,
       worktreePath: "/repo/feature-test-flow",
+      alreadyOpen: false,
     }));
     const create = mock(async () => testWorkspace());
     const createLayout = mock(async (workspace: Workspace) => workspace);
@@ -760,6 +764,161 @@ describe("runWorktree", () => {
     expect(focus).toHaveBeenCalledWith("ws-opened");
     expect(log).toHaveBeenCalledWith(
       "✓ worktree 'feature/test-flow' opened and focused (ws-opened)"
+    );
+  });
+
+  it("focuses without layout when the picker opens a checkout whose workspace is already open", async () => {
+    const candidate: WorktreeCandidate = {
+      id: "worktree:/worktrees/repo/feature-test-flow",
+      kind: "worktree",
+      label: "worktree          feature/test-flow",
+      branch: "feature/test-flow",
+      path: "/worktrees/repo/feature-test-flow",
+    };
+    const openedWorkspace = testWorkspace({
+      workspace_id: "ws-opened",
+      worktree: {
+        checkout_path: "/worktrees/repo/feature-test-flow",
+      },
+    });
+    const open = mock(async () => ({
+      workspace: openedWorkspace,
+      worktreePath: "/worktrees/repo/feature-test-flow",
+      alreadyOpen: true,
+    }));
+    const createLayout = mock(async (workspace: Workspace) => workspace);
+    const focus = mock(async () => {});
+    const log = mock(() => {});
+
+    await runWorktree(
+      [],
+      testRuntime({
+        worktrees: { open, create: mock(async () => testWorkspace()) },
+        workspaces: {
+          list: mock(async () => []),
+          get: mock(async () => openedWorkspace),
+          focus,
+        },
+        discoverCandidates: mock(async () => [candidate]),
+        pickWorktreeCandidate: mock(async () => [
+          worktreeCandidateRow(candidate),
+        ]),
+        createLayout,
+        logger: { log, error: mock(() => {}) },
+      })
+    );
+
+    expect(open).toHaveBeenCalledWith({
+      workspaceId: undefined,
+      cwd: "/repo",
+      path: "/worktrees/repo/feature-test-flow",
+      focus: true,
+    });
+    expect(createLayout).not.toHaveBeenCalled();
+    expect(focus).toHaveBeenCalledWith("ws-opened");
+    expect(log).toHaveBeenCalledWith(
+      "✓ opened existing worktree path '/worktrees/repo/feature-test-flow' for 'feature/test-flow'"
+    );
+  });
+
+  it("focuses without layout when opening an already-open worktree by project and branch", async () => {
+    const openedWorkspace = testWorkspace({
+      workspace_id: "ws-opened",
+      worktree: {
+        checkout_path: "/repo/feature-test-flow",
+      },
+    });
+    const open = mock(async () => ({
+      workspace: openedWorkspace,
+      worktreePath: "/repo/feature-test-flow",
+      alreadyOpen: true,
+    }));
+    const create = mock(async () => testWorkspace());
+    const createLayout = mock(async (workspace: Workspace) => workspace);
+    const focus = mock(async () => {});
+    const log = mock(() => {});
+
+    await runWorktree(
+      ["--project", "/repo", "--branch", "feature/test-flow"],
+      testRuntime({
+        worktrees: { open, create },
+        workspaces: {
+          list: mock(async () => []),
+          get: mock(async () => openedWorkspace),
+          focus,
+        },
+        createLayout,
+        logger: { log, error: mock(() => {}) },
+      })
+    );
+
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(create).not.toHaveBeenCalled();
+    expect(createLayout).not.toHaveBeenCalled();
+    expect(focus).toHaveBeenCalledWith("ws-opened");
+    expect(log).toHaveBeenCalledWith(
+      "✓ opened existing worktree 'feature/test-flow'"
+    );
+  });
+
+  it("skips the layout when the attach fallback opens a checkout whose workspace is already open", async () => {
+    const duplicateBranchError = new HerdrError(
+      ["worktree", "create"],
+      1,
+      "fatal: a branch named 'feature/test-flow' already exists"
+    );
+    const openedWorkspace = testWorkspace({
+      workspace_id: "ws-opened",
+      worktree: {
+        checkout_path: "/repo/feature-test-flow",
+      },
+    });
+    const open = mock(
+      async (options: {
+        workspaceId?: string;
+        cwd?: string;
+        branch?: string;
+        path?: string;
+        label?: string;
+        focus?: boolean;
+      }) => {
+        if (options.branch) {
+          throw duplicateBranchError;
+        }
+
+        return {
+          workspace: openedWorkspace,
+          worktreePath: "/repo/feature-test-flow",
+          alreadyOpen: true,
+        };
+      }
+    );
+    const create = mock(async () => {
+      throw duplicateBranchError;
+    });
+    const createLayout = mock(async (workspace: Workspace) => workspace);
+    const focus = mock(async () => {});
+    const log = mock(() => {});
+
+    await runWorktree(
+      ["--project", "/repo", "--branch", "feature/test-flow"],
+      testRuntime({
+        worktrees: { open, create },
+        workspaces: {
+          list: mock(async () => []),
+          get: mock(async () => openedWorkspace),
+          focus,
+        },
+        createLayout,
+        attachExistingBranch: mock(async () => "/repo/feature-test-flow"),
+        logger: { log, error: mock(() => {}) },
+      })
+    );
+
+    expect(createLayout).not.toHaveBeenCalled();
+    expect(focus).toHaveBeenCalledWith("ws-opened");
+    expect(log).toHaveBeenCalledWith(
+      "✓ attached existing branch 'feature/test-flow' at '/repo/feature-test-flow'"
     );
   });
 });

--- a/src/worktree/worktree.test.ts
+++ b/src/worktree/worktree.test.ts
@@ -60,7 +60,7 @@ function testRuntime(
 }
 
 describe("runWorktree", () => {
-  it("reopens an existing worktree after create hits a duplicate-branch error without relayout", async () => {
+  it("reopens an existing worktree after create hits a duplicate-branch error and applies the layout", async () => {
     const duplicateBranchError = new HerdrError(
       ["worktree", "create"],
       1,
@@ -151,11 +151,26 @@ describe("runWorktree", () => {
       path: "/repo/feature-test-flow",
       focus: true,
     });
-    expect(createLayout).not.toHaveBeenCalled();
+    expect(createLayout).toHaveBeenCalledWith(
+      existingWorkspace,
+      "/repo/feature-test-flow",
+      {
+        projects: { roots: ["/repo"], git_only: false, depth: 1 },
+        ui: { placement: "overlay" },
+        layout: { focus: "terminal" },
+        tabs: [],
+      },
+      {},
+      {},
+      {
+        commandOverride: 'copilot chat "fix this"',
+        branch: "feature/test-flow",
+      }
+    );
     expect(attachExistingBranch).not.toHaveBeenCalled();
-    expect(focus).not.toHaveBeenCalled();
+    expect(focus).toHaveBeenCalledWith("ws-feature");
     expect(log).toHaveBeenCalledWith(
-      "✓ opened existing worktree path '/repo/feature-test-flow' for 'feature/test-flow'"
+      "✓ worktree 'feature/test-flow' opened and focused (ws-feature)"
     );
   });
 
@@ -639,5 +654,112 @@ describe("runWorktree", () => {
 
     expect(open).not.toHaveBeenCalled();
     expect(create).not.toHaveBeenCalled();
+  });
+
+  it("applies the layout when opening an existing worktree checkout", async () => {
+    const candidate: WorktreeCandidate = {
+      id: "worktree:/worktrees/repo/feature-test-flow",
+      kind: "worktree",
+      label: "worktree          feature/test-flow",
+      branch: "feature/test-flow",
+      path: "/worktrees/repo/feature-test-flow",
+    };
+    const openedWorkspace = testWorkspace({
+      workspace_id: "ws-opened",
+      worktree: {
+        checkout_path: "/worktrees/repo/feature-test-flow",
+      },
+    });
+    const open = mock(async () => ({
+      workspace: openedWorkspace,
+      worktreePath: "/worktrees/repo/feature-test-flow",
+    }));
+    const createLayout = mock(async (workspace: Workspace) => workspace);
+    const focus = mock(async () => {});
+    const log = mock(() => {});
+
+    await runWorktree(
+      [],
+      testRuntime({
+        worktrees: { open, create: mock(async () => testWorkspace()) },
+        workspaces: {
+          list: mock(async () => []),
+          get: mock(async () => openedWorkspace),
+          focus,
+        },
+        discoverCandidates: mock(async () => [candidate]),
+        pickWorktreeCandidate: mock(async () => [
+          worktreeCandidateRow(candidate),
+        ]),
+        createLayout,
+        logger: { log, error: mock(() => {}) },
+      })
+    );
+
+    expect(open).toHaveBeenCalledWith({
+      workspaceId: undefined,
+      cwd: "/repo",
+      path: "/worktrees/repo/feature-test-flow",
+      focus: true,
+    });
+    expect(createLayout).toHaveBeenCalledWith(
+      openedWorkspace,
+      "/worktrees/repo/feature-test-flow",
+      {
+        projects: { roots: ["/repo"], git_only: false, depth: 1 },
+        ui: { placement: "overlay" },
+        layout: { focus: "terminal" },
+        tabs: [],
+      },
+      {},
+      {},
+      {
+        commandOverride: undefined,
+        branch: "feature/test-flow",
+      }
+    );
+    expect(focus).toHaveBeenCalledWith("ws-opened");
+    expect(log).toHaveBeenCalledWith(
+      "✓ worktree 'feature/test-flow' opened and focused (ws-opened)"
+    );
+  });
+
+  it("applies the layout when opening an existing worktree by project and branch", async () => {
+    const openedWorkspace = testWorkspace({
+      workspace_id: "ws-opened",
+      worktree: {
+        checkout_path: "/repo/feature-test-flow",
+      },
+    });
+    const open = mock(async () => ({
+      workspace: openedWorkspace,
+      worktreePath: "/repo/feature-test-flow",
+    }));
+    const create = mock(async () => testWorkspace());
+    const createLayout = mock(async (workspace: Workspace) => workspace);
+    const focus = mock(async () => {});
+    const log = mock(() => {});
+
+    await runWorktree(
+      ["--project", "/repo", "--branch", "feature/test-flow"],
+      testRuntime({
+        worktrees: { open, create },
+        workspaces: {
+          list: mock(async () => []),
+          get: mock(async () => openedWorkspace),
+          focus,
+        },
+        createLayout,
+        logger: { log, error: mock(() => {}) },
+      })
+    );
+
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(create).not.toHaveBeenCalled();
+    expect(createLayout).toHaveBeenCalledTimes(1);
+    expect(focus).toHaveBeenCalledWith("ws-opened");
+    expect(log).toHaveBeenCalledWith(
+      "✓ worktree 'feature/test-flow' opened and focused (ws-opened)"
+    );
   });
 });


### PR DESCRIPTION
## Problem

Opening an existing worktree checkout leaves Herdr's default single-shell workspace, while **creating** a worktree bootstraps the configured tab layout. The two paths are inconsistent: opening a previously checked-out worktree gives a bare shell instead of the user's layout.

## Solution

The layout now always applies on checkout-only open — the same bootstrap that creation uses. The three "open existing worktree" paths in the worktree flow run `createProjectLayout` via the shared `bootstrapWorktree` (resolving the checkout `cwd`, honoring repo-local `.sessionizer/config.toml` overrides, then focusing):

- the `open-worktree` intent (an existing checkout picked from the candidate picker)
- the first `worktrees.open` attempt in `openOrCreateWorktree` (the branch already has a worktree)
- the resolver fallback that opens an existing checkout after `create` fails

The gate is the open result itself: when a Herdr workspace attaches (`WorktreeOpenResult.workspace`) the layout runs; when it doesn't (an existing workspace reattach), the path stays focus-only.

- The `open-workspace` intent (focusing a workspace that already exists) is untouched — it may carry user state. A test asserts `createLayout` is never called on that path.
- `bootstrapWorktree` gains a `verb` so the success log reads "opened and focused" vs "created and focused".

## Tests

- `worktree` flow: layout applied on open-checkout with exact `createLayout` args (picker path and CLI `--project --branch` path); open-workspace reattach never bootstraps.
- `bun run typecheck` + `bun test` green (154 passing).

## Docs

CHANGELOG (Unreleased > Changed), README layout-source table, and the `sessionizer-layout-editor` skill bootstrap note.
