### PR TITLE
chore(release): prepare 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.6.2] - 2026-07-26
+
+### Added
+
+- Official Linux platform support (`platforms = ["macos", "linux"]`); README and fzf install hint updated accordingly
+
+### Fixed
+
+- Worktree duplicate-branch recovery now checks git state (`localBranchExists`) instead of sniffing herdr stderr for `a branch named`
+- Config with only `[projects]` (no `[layout]` / `[tabs]`) loads successfully; empty tabs open a plain shell; layout focus/placement stay required when tabs are defined
+
+### Changed
+
+- README documents minimal projects-only config behavior
+
+Thanks @pperanich ([#25](https://github.com/andrewchng/herdr-sessionizer/pull/25), [#28](https://github.com/andrewchng/herdr-sessionizer/pull/28), [#29](https://github.com/andrewchng/herdr-sessionizer/pull/29)).
+
 ## [0.6.1] - 2026-07-21
 
 ### Fixed

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "sessionizer"
 name = "Sessionizer"
-version = "0.6.1"
+version = "0.6.2"
 min_herdr_version = "0.7.0"
 description = "Inspired by ThePrimeagen's tmux-sessionizer: fuzzy pickers to open projects and Git worktrees into Herdr workspaces."
 platforms = ["macos", "linux"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "herdr-plugin-sessionizer",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "type": "module",
   "description": "Herdr plugin inspired by ThePrimeagen's tmux-sessionizer for fuzzy project and worktree picking",


### PR DESCRIPTION
## Summary
- Bump version to 0.6.2 in `package.json` and `herdr-plugin.toml`
- Changelog:
  - Linux platform support (#25)
  - Optional layout/tabs config (#28)
  - Worktree branch-exists recovery (#29)
- Credit @pperanich

## Test plan
- [x] `bun test` (141 pass)
- [x] `bun run typecheck`
- [x] Rebased onto main after #25