### PR TITLE
feat(plugin): compile entrypoints into host-local dist/sessionizer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,11 @@ jobs:
         run: |
           bun run test
           bun run test:integration
+
+      - name: Build plugin binary
+        run: bun run build
+
+      - name: Assert compiled binary
+        run: |
+          test -x dist/sessionizer
+          ./dist/sessionizer --help

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,4 @@ jobs:
         run: |
           test -x dist/sessionizer
           ./dist/sessionizer --help
+          ! ./dist/sessionizer not-a-mode

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
+dist/
 .DS_Store
 **/.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Plugin actions and panes launch a host-local compiled `dist/sessionizer` instead of `bun run` on TypeScript sources ([#38](https://github.com/andrewchng/herdr-sessionizer/pull/38), [#3](https://github.com/andrewchng/herdr-sessionizer/issues/3)). One binary, four modes: `open`, `sessionizer`, `worktree-open`, `worktree`. `herdr plugin install` compiles it after `bun install`; `herdr plugin link` does not — run `bun run build` first. Bun remains required for install/build, not to launch already-built entrypoints.
+
 ## [0.8.0] - 2026-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Inspired by [ThePrimeagen's tmux-sessionizer](https://github.com/ThePrimeagen/tm
 Sessionizer does not install system tools for you.
 
 - [Herdr](https://herdr.dev/) `>= 0.7.4`
-- [Bun](https://bun.sh/) — plugin build and runtime
+- [Bun](https://bun.sh/) — required for **install/build** (and maintainer workflows). After the plugin is built, Herdr launches compiled `dist/sessionizer` — Bun is **not** required merely to open already-built actions/panes.
 - [fzf](https://github.com/junegunn/fzf) — interactive pickers
 
 ```sh
@@ -44,18 +44,24 @@ herdr plugin install andrewchng/herdr-sessionizer --yes
 herdr plugin config-dir sessionizer
 ```
 
+Install runs `bun install` then compiles a host-local `dist/sessionizer` binary. Actions and panes invoke that binary with a mode (`open`, `sessionizer`, `worktree-open`, `worktree`).
+
 Wire keybindings in your Herdr config (see [Example keybindings](#example-keybindings)).
 
 ### Local development
 
+`herdr plugin link` does **not** run the plugin build steps. Compile first, then link:
+
 ```sh
 bun install
+bun run build
 herdr plugin link /path/to/herdr-sessionizer
 ```
 
-After manifest or pane/action changes:
+After TypeScript, manifest, or entrypoint changes, rebuild and re-link:
 
 ```sh
+bun run build
 herdr plugin unlink sessionizer || true
 herdr plugin link /path/to/herdr-sessionizer
 ```
@@ -359,10 +365,12 @@ See [CHANGELOG.md](CHANGELOG.md) for release history.
 bun run typecheck
 bun run test
 bun run test:integration
+bun run build          # produces dist/sessionizer (host-local executable)
 bun run release -- <version> --dry-run
 bun run release:tag -- <version> --dry-run
 bun run release:notes -- <version>
-bun run sessionizer
+bun run sessionizer    # dev: run Sessionizer flow via Bun without compiling
+./dist/sessionizer --help
 ```
 
 `bun run test` runs the unit suite only; `bun run test:integration` runs the real-git sandbox tests for `fetchPullRequestHead` (a tmpdir fake GitHub, no network). The integration suite is excluded from `bun test` and CI runs both — the pre-commit hook exports `GIT_DIR`, which would redirect the sandbox's git commands into the parent repository, so the sandbox suite only ever runs in CI's clean environment.

--- a/README.md
+++ b/README.md
@@ -58,13 +58,35 @@ bun run build
 herdr plugin link /path/to/herdr-sessionizer
 ```
 
-After TypeScript, manifest, or entrypoint changes, rebuild and re-link:
+After TypeScript changes, `bun run build` is enough — Herdr execs `./dist/sessionizer` on the next keypress. Relink only when `herdr-plugin.toml` changes:
 
 ```sh
 bun run build
 herdr plugin unlink sessionizer || true
 herdr plugin link /path/to/herdr-sessionizer
 ```
+
+To skip compile while iterating (keybinds run TypeScript via Bun), point the four manifest `command` arrays at `bun run` and relink. Bun must be on `PATH`. Restore the `./dist/sessionizer` commands before committing — `herdr plugin install` and the published plugin always use the compiled binary.
+
+```toml
+[[actions]]
+id = "open"
+command = ["bun", "run", "src/sessionizer/open-pane.ts"]
+
+[[actions]]
+id = "worktree-open"
+command = ["bun", "run", "src/worktree/open-worktree-pane.ts"]
+
+[[panes]]
+id = "sessionizer"
+command = ["bun", "run", "src/sessionizer/sessionizer-pane.ts"]
+
+[[panes]]
+id = "worktree"
+command = ["bun", "run", "src/worktree/worktree-pane.ts"]
+```
+
+`bun run sessionizer` still runs the Sessionizer flow without linking or compiling.
 
 ## Usage
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -8,24 +8,27 @@ platforms = ["macos", "linux"]
 [[build]]
 command = ["bun", "install", "--frozen-lockfile"]
 
+[[build]]
+command = ["bun", "run", "build"]
+
 [[actions]]
 id = "open"
 title = "Open sessionizer"
-command = ["bun", "run", "src/sessionizer/open-pane.ts"]
+command = ["./dist/sessionizer", "open"]
 
 [[actions]]
 id = "worktree-open"
 title = "Open worktree"
-command = ["bun", "run", "src/worktree/open-worktree-pane.ts"]
+command = ["./dist/sessionizer", "worktree-open"]
 
 [[panes]]
 id = "sessionizer"
 title = "Sessionizer"
 placement = "overlay"
-command = ["bun", "run", "src/sessionizer/sessionizer-pane.ts"]
+command = ["./dist/sessionizer", "sessionizer"]
 
 [[panes]]
 id = "worktree"
 title = "Worktree"
 placement = "overlay"
-command = ["bun", "run", "src/worktree/worktree-pane.ts"]
+command = ["./dist/sessionizer", "worktree"]

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "herdr-worktree": "./src/bin/herdr-worktree.ts"
   },
   "scripts": {
+    "build": "mkdir -p dist && bun build ./src/cli.ts --compile --outfile dist/sessionizer",
     "sessionizer": "bun run src/sessionizer/sessionizer.ts",
     "worktree": "bun run src/bin/herdr-worktree.ts",
     "release": "bun run scripts/release/prep.ts",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, mock } from "bun:test";
+
+import { isMode, main, parseArgs, usage, type Mode } from "./cli.ts";
+
+describe("parseArgs", () => {
+  it("returns help for no args, --help, and -h", () => {
+    expect(parseArgs([])).toEqual({ ok: true, kind: "help" });
+    expect(parseArgs(["--help"])).toEqual({ ok: true, kind: "help" });
+    expect(parseArgs(["-h"])).toEqual({ ok: true, kind: "help" });
+  });
+
+  it("parses each known mode and forwards remaining args", () => {
+    const modes: Mode[] = ["open", "sessionizer", "worktree-open", "worktree"];
+    for (const mode of modes) {
+      expect(parseArgs([mode])).toEqual({
+        ok: true,
+        kind: "run",
+        mode,
+        args: [],
+      });
+      expect(parseArgs([mode, "--project", "/repo"])).toEqual({
+        ok: true,
+        kind: "run",
+        mode,
+        args: ["--project", "/repo"],
+      });
+    }
+  });
+
+  it("rejects unknown modes", () => {
+    expect(parseArgs(["nope"])).toEqual({
+      ok: false,
+      error: "Unknown mode: nope",
+    });
+  });
+});
+
+describe("isMode", () => {
+  it("accepts only the four plugin modes", () => {
+    expect(isMode("open")).toBe(true);
+    expect(isMode("sessionizer")).toBe(true);
+    expect(isMode("worktree-open")).toBe(true);
+    expect(isMode("worktree")).toBe(true);
+    expect(isMode("help")).toBe(false);
+    expect(isMode("")).toBe(false);
+  });
+});
+
+describe("usage", () => {
+  it("lists all four modes", () => {
+    const text = usage();
+    expect(text).toContain("open");
+    expect(text).toContain("sessionizer");
+    expect(text).toContain("worktree-open");
+    expect(text).toContain("worktree");
+  });
+});
+
+describe("main", () => {
+  it("prints usage and exits 0 for help", async () => {
+    const log = mock(() => {});
+    const error = mock(() => {});
+    const originalLog = console.log;
+    const originalError = console.error;
+    console.log = log;
+    console.error = error;
+
+    try {
+      expect(await main([])).toBe(0);
+      expect(await main(["--help"])).toBe(0);
+      expect(log).toHaveBeenCalled();
+      expect(error).not.toHaveBeenCalled();
+    } finally {
+      console.log = originalLog;
+      console.error = originalError;
+    }
+  });
+
+  it("prints usage and exits non-zero for unknown mode", async () => {
+    const log = mock(() => {});
+    const error = mock(() => {});
+    const originalLog = console.log;
+    const originalError = console.error;
+    console.log = log;
+    console.error = error;
+
+    try {
+      expect(await main(["not-a-mode"])).toBe(1);
+      expect(error).toHaveBeenCalled();
+      const joined = error.mock.calls
+        .map((c) => (c as unknown[]).map(String).join(" "))
+        .join("\n");
+      expect(joined).toContain("Unknown mode");
+      expect(joined).toContain("Usage:");
+    } finally {
+      console.log = originalLog;
+      console.error = originalError;
+    }
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,9 +69,7 @@ export async function dispatch(
       await openWorktreePane();
       return;
     case "worktree":
-      await runWorktree(
-        args.length > 0 ? [...args] : buildWorktreeArgvFromEnv()
-      );
+      await runWorktree(args.length > 0 ? args : buildWorktreeArgvFromEnv());
       return;
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,110 @@
+export {};
+
+import { openSessionizerPane } from "./sessionizer/open-pane.ts";
+import { runSessionizer } from "./sessionizer/sessionizer.ts";
+import { openWorktreePane } from "./worktree/open-worktree-pane.ts";
+import { buildWorktreeArgvFromEnv, runWorktree } from "./worktree/worktree.ts";
+
+export const MODES = [
+  "open",
+  "sessionizer",
+  "worktree-open",
+  "worktree",
+] as const;
+
+export type Mode = (typeof MODES)[number];
+
+export type ParseResult =
+  | { ok: true; kind: "help" }
+  | { ok: true; kind: "run"; mode: Mode; args: string[] }
+  | { ok: false; error: string };
+
+export function isMode(value: string): value is Mode {
+  return (MODES as readonly string[]).includes(value);
+}
+
+export function usage(): string {
+  return `Usage:
+  sessionizer <mode> [args...]
+
+Modes:
+  open            Open the Sessionizer pane (action launcher)
+  sessionizer     Run the Sessionizer flow (pane body)
+  worktree-open   Open the Worktree pane (action launcher)
+  worktree        Run the Worktree flow (pane body)
+
+Examples:
+  sessionizer open
+  sessionizer sessionizer
+  sessionizer worktree-open
+  sessionizer worktree --project ~/Projects/my-repo --branch feat/x
+`;
+}
+
+export function parseArgs(argv: readonly string[]): ParseResult {
+  const first = argv[0];
+  if (first === undefined || first === "--help" || first === "-h") {
+    return { ok: true, kind: "help" };
+  }
+
+  if (!isMode(first)) {
+    return { ok: false, error: `Unknown mode: ${first}` };
+  }
+
+  return { ok: true, kind: "run", mode: first, args: argv.slice(1) };
+}
+
+export async function dispatch(
+  mode: Mode,
+  args: readonly string[] = []
+): Promise<void> {
+  switch (mode) {
+    case "open":
+      await openSessionizerPane();
+      return;
+    case "sessionizer":
+      await runSessionizer();
+      return;
+    case "worktree-open":
+      await openWorktreePane();
+      return;
+    case "worktree":
+      await runWorktree(
+        args.length > 0 ? [...args] : buildWorktreeArgvFromEnv()
+      );
+      return;
+  }
+}
+
+export async function main(
+  argv: readonly string[] = process.argv.slice(2)
+): Promise<number> {
+  const parsed = parseArgs(argv);
+
+  if (!parsed.ok) {
+    console.error(parsed.error);
+    console.error(usage());
+    return 1;
+  }
+
+  if (parsed.kind === "help") {
+    console.log(usage());
+    return 0;
+  }
+
+  await dispatch(parsed.mode, parsed.args);
+  return 0;
+}
+
+if (import.meta.main) {
+  main()
+    .then((code) => {
+      if (code !== 0) {
+        process.exit(code);
+      }
+    })
+    .catch((error: unknown) => {
+      console.error(error instanceof Error ? error.message : error);
+      process.exit(1);
+    });
+}

--- a/src/sessionizer/open-pane.ts
+++ b/src/sessionizer/open-pane.ts
@@ -3,7 +3,8 @@ export {};
 import { Herdr } from "../client/herdr.ts";
 import { loadConfig } from "../config/config.ts";
 
-async function run(): Promise<void> {
+/** Action launcher: open the Sessionizer pane entrypoint. */
+export async function openSessionizerPane(): Promise<void> {
   const pluginId = process.env.HERDR_PLUGIN_ID;
   if (!pluginId) {
     throw new Error(
@@ -44,7 +45,9 @@ async function run(): Promise<void> {
   await herdr.run(args);
 }
 
-run().catch((error: unknown) => {
-  console.error(error instanceof Error ? error.message : error);
-  process.exit(1);
-});
+if (import.meta.main) {
+  openSessionizerPane().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/src/sessionizer/open-pane.ts
+++ b/src/sessionizer/open-pane.ts
@@ -3,7 +3,6 @@ export {};
 import { Herdr } from "../client/herdr.ts";
 import { loadConfig } from "../config/config.ts";
 
-/** Action launcher: open the Sessionizer pane entrypoint. */
 export async function openSessionizerPane(): Promise<void> {
   const pluginId = process.env.HERDR_PLUGIN_ID;
   if (!pluginId) {

--- a/src/worktree/open-worktree-pane.ts
+++ b/src/worktree/open-worktree-pane.ts
@@ -3,7 +3,7 @@ export {};
 import { Herdr } from "../client/herdr.ts";
 import { loadConfig } from "../config/config.ts";
 
-async function openWorktreePane(
+export async function openWorktreePane(
   extraEnv: Record<string, string> = {}
 ): Promise<void> {
   const pluginId = process.env.HERDR_PLUGIN_ID;

--- a/src/worktree/worktree-pane.ts
+++ b/src/worktree/worktree-pane.ts
@@ -1,23 +1,8 @@
 export {};
 
-import { runWorktree } from "./worktree.ts";
+import { buildWorktreeArgvFromEnv, runWorktree } from "./worktree.ts";
 
-runWorktree(buildArgvFromEnv()).catch((error: unknown) => {
+runWorktree(buildWorktreeArgvFromEnv()).catch((error: unknown) => {
   console.error(error instanceof Error ? error.message : error);
   process.exit(1);
 });
-
-function buildArgvFromEnv(): string[] {
-  const argv: string[] = [];
-  if (process.env.WORKTREE_PROJECT) {
-    argv.push("--project", process.env.WORKTREE_PROJECT);
-  }
-  if (process.env.WORKTREE_BRANCH) {
-    argv.push("--branch", process.env.WORKTREE_BRANCH);
-  }
-  const command = process.env.WORKTREE_COMMAND ?? process.env.WORKTREE_CONTEXT;
-  if (command) {
-    argv.push("--command", command);
-  }
-  return argv;
-}

--- a/src/worktree/worktree.test.ts
+++ b/src/worktree/worktree.test.ts
@@ -10,7 +10,7 @@ import {
   WORKTREE_CANDIDATE_ROW_DELIMITER,
   worktreeCandidateRow,
 } from "./candidates.ts";
-import { runWorktree } from "./worktree.ts";
+import { buildWorktreeArgvFromEnv, runWorktree } from "./worktree.ts";
 
 function testWorkspace(overrides?: Partial<Workspace>): Workspace {
   return {
@@ -1080,5 +1080,36 @@ describe("runWorktree", () => {
     expect(log).toHaveBeenCalledWith(
       "✓ attached existing branch 'feature/test-flow' at '/repo/feature-test-flow'"
     );
+  });
+});
+
+describe("buildWorktreeArgvFromEnv", () => {
+  it("builds argv from project, branch, and command env", () => {
+    expect(
+      buildWorktreeArgvFromEnv({
+        WORKTREE_PROJECT: "/repo",
+        WORKTREE_BRANCH: "feat/x",
+        WORKTREE_COMMAND: "echo hi",
+      })
+    ).toEqual([
+      "--project",
+      "/repo",
+      "--branch",
+      "feat/x",
+      "--command",
+      "echo hi",
+    ]);
+  });
+
+  it("falls back to WORKTREE_CONTEXT for command", () => {
+    expect(
+      buildWorktreeArgvFromEnv({
+        WORKTREE_CONTEXT: "fix validation",
+      })
+    ).toEqual(["--command", "fix validation"]);
+  });
+
+  it("returns empty argv when no worktree env is set", () => {
+    expect(buildWorktreeArgvFromEnv({})).toEqual([]);
   });
 });

--- a/src/worktree/worktree.ts
+++ b/src/worktree/worktree.ts
@@ -27,6 +27,24 @@ export async function runWorktree(
   await runWorktreeFlow(argv, runtime);
 }
 
+/** Build worktree CLI argv from pane env vars (Herdr --env passthrough). */
+export function buildWorktreeArgvFromEnv(
+  env: Record<string, string | undefined> = process.env
+): string[] {
+  const argv: string[] = [];
+  if (env.WORKTREE_PROJECT) {
+    argv.push("--project", env.WORKTREE_PROJECT);
+  }
+  if (env.WORKTREE_BRANCH) {
+    argv.push("--branch", env.WORKTREE_BRANCH);
+  }
+  const command = env.WORKTREE_COMMAND ?? env.WORKTREE_CONTEXT;
+  if (command) {
+    argv.push("--command", command);
+  }
+  return argv;
+}
+
 async function promptBranchName(): Promise<string | null> {
   while (true) {
     // Use fzf free-text (not raw-mode readline) so Esc cancels the same way


### PR DESCRIPTION
## Summary

- Replace `bun run` TypeScript plugin action/pane launches with a single host-local compiled binary: `dist/sessionizer`
- One binary, four modes: `open`, `sessionizer`, `worktree-open`, `worktree` (action launchers + pane bodies)
- `[[build]]` runs frozen install then `bun run build`; CI asserts `dist/sessionizer` is executable
- README clarifies Bun is still required for install/build, not merely to launch already-built entrypoints
- Action/pane IDs unchanged — existing keybinds keep working

Closes #3

## Test plan

- [x] `bun run typecheck`
- [x] `bun test` (151 pass)
- [x] `bun run build` produces executable `dist/sessionizer`
- [x] `./dist/sessionizer --help` / unknown mode behavior
- [x] Binary runs without Bun on `PATH`
- [x] After `herdr plugin link`, `sessionizer.open` and `sessionizer.worktree-open` succeed via `./dist/sessionizer <mode>`
- [ ] CI green on the PR
- [ ] Optional: full interactive picker happy path after reinstall/link

## Out of scope

- Prebuilt release assets / zero-Bun install (#4)
- Optional `herdr-worktree` package bin compilation