### PR TITLE
chore(release): prepare 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-01
+
 ### Added
 
 - `[ui].placement` for how Sessionizer / Worktree pickers open in Herdr: `overlay`, `split`, or `popup` (popup requires Herdr `>= 0.7.4`)

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "sessionizer"
 name = "Sessionizer"
-version = "0.6.2"
+version = "0.7.0"
 min_herdr_version = "0.7.4"
 description = "Inspired by ThePrimeagen's tmux-sessionizer: fuzzy pickers to open projects and Git worktrees into Herdr workspaces."
 platforms = ["macos", "linux"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "herdr-plugin-sessionizer",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "description": "Herdr plugin inspired by ThePrimeagen's tmux-sessionizer for fuzzy project and worktree picking",


### PR DESCRIPTION
## Summary

- Bump `package.json` and `herdr-plugin.toml` to **0.7.0**
- Promote CHANGELOG Unreleased notes to `## [0.7.0] - 2026-08-01`
- Requires Herdr `>= 0.7.4` (already set via #37)

## After merge

Tag and publish:

```sh
bun run release:tag -- 0.7.0
bun run release:notes -- 0.7.0 > /tmp/release-notes-0.7.0.md
gh release create v0.7.0 --title "v0.7.0" --notes-file /tmp/release-notes-0.7.0.md --latest
```

Or say the word and I'll ship from clean main after this merges.