### PR TITLE
docs: document remote-use keybindings for sessionizer flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ command = "sessionizer.worktree-open"
 description = "open worktree workspace"
 ```
 
+### Remote use (`herdr --remote`)
+
+When you attach to a remote Herdr server, the Sessionizer keybindings above are read from the **remote** server's config, but Herdr's remote client may resolve keybindings from the machine you launched it from instead. If `sessionizer.open` / `sessionizer.worktree-open` do nothing under `herdr --remote`, attach with the server's keybindings:
+
+```sh
+herdr --remote <target> --remote-keybindings server
+```
+
+Alternatively, add the same `prefix+f` / `prefix+up` bindings to the Herdr config on the machine that launches `herdr --remote`.
+
+> The plugin itself runs on the remote host — bun, fzf, and the plugin checkout must be present there. See [Requirements](#requirements) for the runtime prerequisites.
+
 ## Layout configuration
 
 When Sessionizer **creates** a new project or worktree workspace, it applies the layout from `config.toml`. Existing workspaces are only focused — the layout is not reapplied.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ When you attach to a remote Herdr server, the Sessionizer keybindings above are 
 herdr --remote <target> --remote-keybindings server
 ```
 
-Alternatively, add the same `prefix+f` / `prefix+up` bindings to the Herdr config on the machine that launches `herdr --remote`.
+Bindings added to the machine that launches `herdr --remote` do **not** trigger the plugin in a remote session — they must come from the remote server's keybindings.
 
 > The plugin itself runs on the remote host — bun, fzf, and the plugin checkout must be present there. See [Requirements](#requirements) for the runtime prerequisites.
 


### PR DESCRIPTION
## What

Document the remote-use gotcha for Sessionizer keybindings, learned from a real failure:

- Under `herdr --remote <target>`, keybindings may resolve from the launching machine rather than the remote server's config, so `sessionizer.open` / `sessionizer.worktree-open` can silently do nothing.
- The fix that works: attach with `herdr --remote <target> --remote-keybindings server`.
- Explicitly notes that bindings on the launching machine do **not** trigger the plugin in a remote session (verified: they were present locally and still failed).
- Also notes the plugin runs on the remote host — bun, fzf, and the plugin checkout must exist there.

## Verification

- README-only change; full suite passes (152 pass / 0 fail).
