### PR TITLE
chore: prep v0.8.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## [Unreleased]
+## [0.8.1] - 2026-08-29
 
 ### Changed
 
-- Plugin actions and panes launch a host-local compiled `dist/sessionizer` instead of `bun run` on TypeScript sources ([#38](https://github.com/andrewchng/herdr-sessionizer/pull/38), [#3](https://github.com/andrewchng/herdr-sessionizer/issues/3)). One binary, four modes: `open`, `sessionizer`, `worktree-open`, `worktree`. `herdr plugin install` compiles it after `bun install`; `herdr plugin link` does not — run `bun run build` first. Bun remains required for install/build, not to launch already-built entrypoints.
+- Plugin actions and panes launch a host-local compiled `dist/sessionizer` instead of `bun run` on TypeScript sources ([#38](https://github.com/andrewchng/herdr-sessionizer/pull/38), [#3](https://github.com/andrewchng/herdr-sessionizer/issues/3)). One binary, four modes: `open`, `sessionizer`, `worktree-open`, `worktree`. `herdr plugin install` compiles it after `bun install`; `herdr plugin link` does not — run `bun run build` first. Bun remains required for install/build, not to launch already-built entrypoints. Existing GitHub installs pick this up with `herdr plugin install andrewchng/herdr-sessionizer --yes` from a terminal that has Bun on `PATH`.
 
 ## [0.8.0] - 2026-08-16
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "sessionizer"
 name = "Sessionizer"
-version = "0.8.0"
+version = "0.8.1"
 min_herdr_version = "0.7.4"
 description = "Inspired by ThePrimeagen's tmux-sessionizer: fuzzy pickers to open projects and Git worktrees into Herdr workspaces."
 platforms = ["macos", "linux"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "herdr-plugin-sessionizer",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "description": "Herdr plugin inspired by ThePrimeagen's tmux-sessionizer for fuzzy project and worktree picking",


### PR DESCRIPTION
## Summary

- Bump `package.json` and `herdr-plugin.toml` to 0.8.0 → 0.8.1
- Move the compiled `dist/sessionizer` Unreleased notes into `## [0.8.1]`

Follows #38. Existing GitHub installs update with `herdr plugin install andrewchng/herdr-sessionizer --yes` from a terminal that has Bun on PATH.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test`